### PR TITLE
build: use platform transitions for zig binaries

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 
 bazel_dep(name = "rules_zig", version = "0.15.1")
 bazel_dep(name = "apple_support", version = "2.5.4")
+bazel_dep(name = "bazel_lib", version = "3.2.2")
 bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "platforms", version = "1.1.0")

--- a/cmd/darwin_actiond/BUILD.bazel
+++ b/cmd/darwin_actiond/BUILD.bazel
@@ -74,19 +74,19 @@ set -euo pipefail
 anchor_c="$(@D)/darwin-standalone-payload-anchor.c"
 anchor_o="$(@D)/darwin-standalone-payload-anchor.o"
 printf '%s\n' 'void actiond_standalone_payload_anchor(void) {}' > "$${anchor_c}"
-/usr/bin/clang -c -arch arm64 "$${anchor_c}" -o "$${anchor_o}"
-/usr/bin/ld -r -arch arm64 "$${anchor_o}" \
-  -sectcreate __ACTIOND __kernel "$(location //vm:linux_kernel_zst)" \
-  -sectcreate __ACTIOND __initramfs "$(location //vm:initramfs)" \
-  -sectcreate __ACTIOND __runtimes "$(location //runtimes:runtimes_squashfs_aarch64)" \
-  -o "$@"
+"$(execpath @llvm//tools:clang)" -c -target arm64-apple-macos14.0 "$${anchor_c}" -o "$${anchor_o}"
+"$(execpath @llvm//tools:llvm-objcopy)" \
+  --add-section __ACTIOND,__kernel="$(location //vm:linux_kernel_zst)" \
+  --add-section __ACTIOND,__initramfs="$(location //vm:initramfs)" \
+  --add-section __ACTIOND,__runtimes="$(location //runtimes:runtimes_squashfs_aarch64)" \
+  "$${anchor_o}" "$@"
 """,
-    exec_compatible_with = ["@platforms//os:macos"],
-    tags = [
-        "local",
-        "manual",
-    ],
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:macos"],
+    tools = [
+        "@llvm//tools:clang",
+        "@llvm//tools:llvm-objcopy",
+    ],
 )
 
 cc_library(

--- a/cmd/linux_actiond/BUILD.bazel
+++ b/cmd/linux_actiond/BUILD.bazel
@@ -1,56 +1,61 @@
-load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_configure_binary")
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_binary")
+load("@rules_zig//zig:defs.bzl", "zig_binary")
 
 zig_binary(
     name = "linux-actiond",
     main = "main.zig",
     strip_debug_symbols = True,
-    deps = ["//src:actiond"],
     visibility = ["//visibility:public"],
+    deps = ["//src:actiond"],
 )
 
-zig_configure_binary(
+platform_transition_binary(
     name = "linux-actiond-linux-aarch64-raw",
-    actual = ":linux-actiond",
-    target = "//platforms:linux_aarch64",
-    zig_version = "0.16.0",
+    basename = "linux-actiond-linux-aarch64-raw",
+    binary = ":linux-actiond",
+    target_platform = "//platforms:linux_aarch64",
 )
 
 genrule(
     name = "linux-actiond-linux-aarch64",
-    srcs = [":linux-actiond-linux-aarch64-raw"],
     outs = ["linux-actiond-linux-aarch64.bin"],
     cmd = """
 set -euo pipefail
-cp "$(location :linux-actiond-linux-aarch64-raw)" "$@"
+cp "$(execpath :linux-actiond-linux-aarch64-raw)" "$@"
 chmod +w "$@"
 "$(execpath @llvm//tools:llvm-strip)" --strip-all "$@"
 chmod +x "$@"
-""",
+    """,
     executable = True,
-    tools = ["@llvm//tools:llvm-strip"],
+    tools = [
+        ":linux-actiond-linux-aarch64-raw",
+        "@llvm//tools:llvm-strip",
+    ],
     visibility = ["//visibility:public"],
 )
 
-zig_configure_binary(
+platform_transition_binary(
     name = "linux-actiond-linux-x86_64-raw",
-    actual = ":linux-actiond",
-    target = "//platforms:linux_x86_64",
-    zig_version = "0.16.0",
+    basename = "linux-actiond-linux-x86_64-raw",
+    binary = ":linux-actiond",
+    target_platform = "//platforms:linux_x86_64",
 )
 
 genrule(
     name = "linux-actiond-linux-x86_64",
-    srcs = [":linux-actiond-linux-x86_64-raw"],
     outs = ["linux-actiond-linux-x86_64.bin"],
     cmd = """
 set -euo pipefail
-cp "$(location :linux-actiond-linux-x86_64-raw)" "$@"
+cp "$(execpath :linux-actiond-linux-x86_64-raw)" "$@"
 chmod +w "$@"
 "$(execpath @llvm//tools:llvm-strip)" --strip-all "$@"
 chmod +x "$@"
-""",
+    """,
     executable = True,
-    tools = ["@llvm//tools:llvm-strip"],
+    tools = [
+        ":linux-actiond-linux-x86_64-raw",
+        "@llvm//tools:llvm-strip",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/linux_actiond_guest/BUILD.bazel
+++ b/cmd/linux_actiond_guest/BUILD.bazel
@@ -1,32 +1,35 @@
-load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_configure_binary")
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_binary")
+load("@rules_zig//zig:defs.bzl", "zig_binary")
 
 zig_binary(
     name = "linux-actiond-guest",
     main = "main.zig",
     strip_debug_symbols = True,
-    deps = ["//src:actiond"],
     visibility = ["//visibility:public"],
+    deps = ["//src:actiond"],
 )
 
-zig_configure_binary(
+platform_transition_binary(
     name = "linux-actiond-guest-aarch64-raw",
-    actual = ":linux-actiond-guest",
-    target = "//platforms:linux_aarch64",
-    zig_version = "0.16.0",
+    basename = "linux-actiond-guest-aarch64-raw",
+    binary = ":linux-actiond-guest",
+    target_platform = "//platforms:linux_aarch64",
 )
 
 genrule(
     name = "linux-actiond-guest-aarch64",
-    srcs = [":linux-actiond-guest-aarch64-raw"],
     outs = ["linux-actiond-guest-aarch64.bin"],
     cmd = """
 set -euo pipefail
-cp "$(location :linux-actiond-guest-aarch64-raw)" "$@"
+cp "$(execpath :linux-actiond-guest-aarch64-raw)" "$@"
 chmod +w "$@"
 "$(execpath @llvm//tools:llvm-strip)" --strip-all "$@"
 chmod +x "$@"
-""",
+    """,
     executable = True,
-    tools = ["@llvm//tools:llvm-strip"],
+    tools = [
+        ":linux-actiond-guest-aarch64-raw",
+        "@llvm//tools:llvm-strip",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_configure_binary", "zig_test")
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_binary")
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_test")
 
 zig_binary(
     name = "initramfs_newc",
@@ -47,20 +48,20 @@ zig_binary(
     deps = ["@zstd"],
 )
 
-zig_configure_binary(
+platform_transition_binary(
     name = "e2e_action_tool_linux_aarch64",
-    actual = ":e2e_action_tool",
-    target = "//platforms:linux_aarch64",
+    basename = "e2e_action_tool_linux_aarch64",
+    binary = ":e2e_action_tool",
+    target_platform = "//platforms:linux_aarch64",
     visibility = ["//visibility:public"],
-    zig_version = "0.16.0",
 )
 
-zig_configure_binary(
+platform_transition_binary(
     name = "e2e_action_tool_linux_x86_64",
-    actual = ":e2e_action_tool",
-    target = "//platforms:linux_x86_64",
+    basename = "e2e_action_tool_linux_x86_64",
+    binary = ":e2e_action_tool",
+    target_platform = "//platforms:linux_x86_64",
     visibility = ["//visibility:public"],
-    zig_version = "0.16.0",
 )
 
 zig_test(


### PR DESCRIPTION
## Summary
- add bazel_lib for platform_transition_binary
- replace zig_configure_binary wrappers with platform_transition_binary for Linux actiond, guest actiond, and e2e action tools
- move transitioned binary inputs into genrule tools so $(execpath ...) resolves the executable unambiguously

## Validation
- covered by the final split stack validation:
  - bazel build --config=remote --config=remote_default //cmd/linux_actiond:linux-actiond-linux-aarch64 //cmd/linux_actiond:linux-actiond-linux-x86_64 //cmd/linux_actiond_guest:linux-actiond-guest-aarch64 //cmd/darwin_actiond:darwin-actiond-bin //cmd/darwin_actiond:darwin-actiond-standalone-bin
  - bazel test //src:unit_tests