### PR TITLE
build: generate darwin payload with llvm tools

### DIFF
--- a/cmd/darwin_actiond/BUILD.bazel
+++ b/cmd/darwin_actiond/BUILD.bazel
@@ -74,19 +74,19 @@ set -euo pipefail
 anchor_c="$(@D)/darwin-standalone-payload-anchor.c"
 anchor_o="$(@D)/darwin-standalone-payload-anchor.o"
 printf '%s\n' 'void actiond_standalone_payload_anchor(void) {}' > "$${anchor_c}"
-/usr/bin/clang -c -arch arm64 "$${anchor_c}" -o "$${anchor_o}"
-/usr/bin/ld -r -arch arm64 "$${anchor_o}" \
-  -sectcreate __ACTIOND __kernel "$(location //vm:linux_kernel_zst)" \
-  -sectcreate __ACTIOND __initramfs "$(location //vm:initramfs)" \
-  -sectcreate __ACTIOND __runtimes "$(location //runtimes:runtimes_squashfs_aarch64)" \
-  -o "$@"
+"$(execpath @llvm//tools:clang)" -c -target arm64-apple-macos14.0 "$${anchor_c}" -o "$${anchor_o}"
+"$(execpath @llvm//tools:llvm-objcopy)" \
+  --add-section __ACTIOND,__kernel="$(location //vm:linux_kernel_zst)" \
+  --add-section __ACTIOND,__initramfs="$(location //vm:initramfs)" \
+  --add-section __ACTIOND,__runtimes="$(location //runtimes:runtimes_squashfs_aarch64)" \
+  "$${anchor_o}" "$@"
 """,
-    exec_compatible_with = ["@platforms//os:macos"],
-    tags = [
-        "local",
-        "manual",
-    ],
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:macos"],
+    tools = [
+        "@llvm//tools:clang",
+        "@llvm//tools:llvm-objcopy",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
## Summary
- replace hard-coded /usr/bin/clang and /usr/bin/ld payload generation with @llvm//tools:clang and llvm-objcopy
- remove the local-only tag and macOS exec constraint from the standalone payload genrule
- set the anchor object target to arm64-apple-macos14.0 so the payload object matches the final link minimum OS

## Validation
- bazel build --config=remote --config=remote_default //cmd/darwin_actiond:darwin-actiond-standalone-bin
- bazel build --config=remote --config=remote_default --remote_download_outputs=all //cmd/darwin_actiond:darwin-standalone-payload
- llvm otool -l bazel-bin/cmd/darwin_actiond/darwin-standalone-payload.o confirmed LC_BUILD_VERSION minos 14.0 and __ACTIOND payload sections
- bazel test //src:unit_tests