### PR TITLE
build: link zig binaries with cc toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 common --enable_platform_specific_config
+common --@rules_zig//zig/settings:use_cc_common_link=true
 
 build:linux --sandbox_add_mount_pair=/tmp
 build:macos --sandbox_add_mount_pair=/var/tmp

--- a/cmd/darwin_actiond/BUILD.bazel
+++ b/cmd/darwin_actiond/BUILD.bazel
@@ -1,12 +1,6 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load("@rules_zig//zig:defs.bzl", "zig_binary")
-
-MACOS_SDK = "@macos_sdk//sysroot:sysroot"
-
-MACOS_SDK_LINKOPTS = [
-    "-F$(execpath %s)/System/Library/Frameworks" % MACOS_SDK,
-    "-L$(execpath %s)/usr/lib" % MACOS_SDK,
-]
 
 objc_library(
     name = "vz_bridge",
@@ -24,9 +18,6 @@ objc_library(
 
 zig_binary(
     name = "darwin-actiond-bin",
-    data = [MACOS_SDK],
-    extra_srcs = [MACOS_SDK],
-    linkopts = MACOS_SDK_LINKOPTS,
     main = "main.zig",
     strip_debug_symbols = True,
     target_compatible_with = ["@platforms//os:macos"],
@@ -59,21 +50,11 @@ chmod +x "$@"
 
 zig_binary(
     name = "darwin-actiond-standalone-bin",
-    data = [
-        ":darwin-standalone-payload",
-        MACOS_SDK,
-    ],
-    extra_srcs = [
-        ":darwin-standalone-payload",
-        MACOS_SDK,
-    ],
-    linkopts = [
-        "$(location :darwin-standalone-payload)",
-    ] + MACOS_SDK_LINKOPTS,
     main = "main.zig",
     strip_debug_symbols = True,
     target_compatible_with = ["@platforms//os:macos"],
     deps = [
+        ":darwin-standalone-payload-lib",
         ":vz_bridge",
         "//src:actiond",
         "@zstd",
@@ -106,6 +87,13 @@ printf '%s\n' 'void actiond_standalone_payload_anchor(void) {}' > "$${anchor_c}"
         "manual",
     ],
     target_compatible_with = ["@platforms//os:macos"],
+)
+
+cc_library(
+    name = "darwin-standalone-payload-lib",
+    srcs = [":darwin-standalone-payload"],
+    target_compatible_with = ["@platforms//os:macos"],
+    alwayslink = True,
 )
 
 genrule(


### PR DESCRIPTION
## Summary
- enable rules_zig cc_common linking
- remove manual macOS SDK library/framework wiring from Darwin Zig targets
- link the standalone payload object through a cc_library with alwayslink instead of direct Zig linkopts

## Validation
- previously validated as part of the final tree with:
  - bazel build --config=remote --config=remote_default //cmd/linux_actiond:linux-actiond-linux-aarch64 //cmd/linux_actiond:linux-actiond-linux-x86_64 //cmd/linux_actiond_guest:linux-actiond-guest-aarch64 //cmd/darwin_actiond:darwin-actiond-bin //cmd/darwin_actiond:darwin-actiond-standalone-bin
  - bazel test //src:unit_tests