### PR TITLE
build: make VM artifact generation hermetic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ pointing at `/Users/dzbarsky/linux.bzl` and verify the kernel with the remote
 Bazel config:
 
 ```bash
-bazel build --config=remote //vm:linux_kernel_zst
+bazel build --config=remote //vm:linux_kernel_aarch64_zst
 ```
 
 Use `--config=remote` for large kernel/package Bazel builds from this repo

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,7 @@ bazel_dep(name = "linux.bzl", version = "0.0.0")
 bazel_dep(name = "squashfs-tools", version = "4.7.5")
 bazel_dep(name = "zstd", version = "1.5.7.bcr.1")
 bazel_dep(name = "codesign.bzl", version = "0.0.13")
+bazel_dep(name = "gawk", version = "5.3.2.bcr.3")
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -27,9 +28,9 @@ http_archive(
 
 archive_override(
     module_name = "linux.bzl",
-    integrity = "sha256-HvmX1dVoB4AL5Xh7ueNUq6ibi/o9DSIdUrHYFyrsF/4=",
-    strip_prefix = "linux.bzl-7fc0e206a0147d878e6e18ae7b71e5567d1756c9",
-    urls = ["https://github.com/hermeticbuild/linux.bzl/archive/7fc0e206a0147d878e6e18ae7b71e5567d1756c9.tar.gz"],
+    integrity = "sha256-5viG+cB4AYYHnjPPmTIy2De3L0fqj+DdcaloVrmTr0k=",
+    strip_prefix = "linux.bzl-d6b1b37708be6d285941d5e1b62725b792686bcd",
+    urls = ["https://github.com/hermeticbuild/linux.bzl/archive/d6b1b37708be6d285941d5e1b62725b792686bcd.tar.gz"],
 )
 
 single_version_override(
@@ -112,23 +113,23 @@ linux_kernel.extra_source(
     source_dir = "fs/actiondfs",
 )
 linux_kernel.kconfig(
-    name = "actiond_vm_kconfig",
+    name = "actiond_vm_aarch64_kconfig",
     config = "//vm:linux.config",
 )
 linux_kernel.compact(
-    name = "actiond_vm_compact",
+    name = "actiond_vm_aarch64_compact",
     config = "//vm:linux.config",
     config_mode = "allnoconfig",
     config_name = "aarch64",
     extra_sources = ["actiondfs"],
-    kernel_name = "linux_kernel",
+    kernel_name = "linux_kernel_aarch64",
     kernel_package = "vm",
     source_repo = "linux_6_18_2",
 )
 use_repo(
     linux_kernel,
-    "actiond_vm_compact",
-    "actiond_vm_kconfig",
+    "actiond_vm_aarch64_compact",
+    "actiond_vm_aarch64_kconfig",
     "linux_6_18_2",
 )
 

--- a/cmd/darwin-actiond/BUILD.bazel
+++ b/cmd/darwin-actiond/BUILD.bazel
@@ -34,12 +34,12 @@ cc_library(
     name = "darwin-payload-sections",
     additional_linker_inputs = [
         "//runtimes:runtimes_squashfs_aarch64",
-        "//vm:initramfs",
-        "//vm:linux_kernel_zst",
+        "//vm:initramfs_aarch64",
+        "//vm:linux_kernel_aarch64_zst",
     ],
     linkopts = [
-        "-Wl,-sectcreate,__ACTIOND,__kernel,$(location //vm:linux_kernel_zst)",
-        "-Wl,-sectcreate,__ACTIOND,__initramfs,$(location //vm:initramfs)",
+        "-Wl,-sectcreate,__ACTIOND,__kernel,$(location //vm:linux_kernel_aarch64_zst)",
+        "-Wl,-sectcreate,__ACTIOND,__initramfs,$(location //vm:initramfs_aarch64)",
         "-Wl,-sectcreate,__ACTIOND,__runtimes,$(location //runtimes:runtimes_squashfs_aarch64)",
     ],
     target_compatible_with = ["@platforms//os:macos"],

--- a/cmd/linux_actiond_guest/BUILD.bazel
+++ b/cmd/linux_actiond_guest/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@bazel_lib//lib:transitions.bzl", "platform_transition_binary")
 load("@rules_zig//zig:defs.bzl", "zig_binary")
 
 zig_binary(
@@ -7,29 +6,4 @@ zig_binary(
     strip_debug_symbols = True,
     visibility = ["//visibility:public"],
     deps = ["//src:actiond"],
-)
-
-platform_transition_binary(
-    name = "linux-actiond-guest-aarch64-raw",
-    basename = "linux-actiond-guest-aarch64-raw",
-    binary = ":linux-actiond-guest",
-    target_platform = "//platforms:linux_aarch64",
-)
-
-genrule(
-    name = "linux-actiond-guest-aarch64",
-    outs = ["linux-actiond-guest-aarch64.bin"],
-    cmd = """
-set -euo pipefail
-cp "$(execpath :linux-actiond-guest-aarch64-raw)" "$@"
-chmod +w "$@"
-"$(execpath @llvm//tools:llvm-strip)" --strip-all "$@"
-chmod +x "$@"
-    """,
-    executable = True,
-    tools = [
-        ":linux-actiond-guest-aarch64-raw",
-        "@llvm//tools:llvm-strip",
-    ],
-    visibility = ["//visibility:public"],
 )

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -1,17 +1,23 @@
 platform(
-    name = "linux_aarch64",
+    name = "linux_aarch64_musl",
     constraint_values = [
         "@platforms//cpu:aarch64",
         "@platforms//os:linux",
+        "@llvm//constraints/libc:musl",
+        "@llvm//constraints/pie:off",
+        "@rules_zig//zig/platforms/abi:musl",
     ],
     visibility = ["//visibility:public"],
 )
 
 platform(
-    name = "linux_x86_64",
+    name = "linux_x86_64_musl",
     constraint_values = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
+        "@llvm//constraints/libc:musl",
+        "@llvm//constraints/pie:off",
+        "@rules_zig//zig/platforms/abi:musl",
     ],
     visibility = ["//visibility:public"],
 )

--- a/runtimes/squashfs.bzl
+++ b/runtimes/squashfs.bzl
@@ -1,80 +1,111 @@
-_RUNTIME_SQUASHFS_CMD = """
-set -euo pipefail
-pseudo="$(@D)/@PSEUDO_NAME@.pseudo"
-rm -f "$${pseudo}"
-cat > "$${pseudo}" <<'EOF'
-/common/root/etc/hosts F 0 0644 0 0 printf '127.0.0.1 localhost\\n::1 localhost ip6-localhost ip6-loopback\\n'
-/common/root/etc/nsswitch.conf F 0 0644 0 0 printf 'passwd: files\\ngroup: files\\nhosts: files dns\\n'
-EOF
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+_RUNTIME_SQUASHFS_SCRIPT = """#!/bin/sh
+set -eu
+output="${OUTPUT:?}"
+mksquashfs="${MKSQUASHFS:?}"
+pseudo="${output}.pseudo"
+printf '%s\n' \
+  "/common/root/etc/hosts F 0 0644 0 0 printf '127.0.0.1 localhost\\n::1 localhost ip6-localhost ip6-loopback\\n'" \
+  "/common/root/etc/nsswitch.conf F 0 0644 0 0 printf 'passwd: files\\ngroup: files\\nhosts: files dns\\n'" \
+  > "${pseudo}"
 
 append_runtime() {
-  local entries="$$1"
-  local libc="$$2"
-  local arch="$$3"
-  local manifest="$$4"
-  local repo_root
-  repo_root="$$(dirname "$${manifest}")"
+  entries="$1"
+  libc="$2"
+  arch="$3"
+  manifest="$4"
+  repo_root="${manifest%/*}"
 
-  printf '/libc/%s/%s/runtime_manifest.json l %s\\n' "$${libc}" "$${arch}" "$${manifest}" >> "$${pseudo}"
-  while IFS="$$(printf '\\t')" read -r kind rel target; do
-    case "$${kind}" in
+  printf '/libc/%s/%s/runtime_manifest.json l %s\\n' "${libc}" "${arch}" "${manifest}" >> "${pseudo}"
+  while IFS="$(printf '\\t')" read -r kind rel target; do
+    case "${kind}" in
       d)
-        printf '/libc/%s/%s/root/%s D 0 0755 0 0\\n' "$${libc}" "$${arch}" "$${rel}" >> "$${pseudo}"
+        printf '/libc/%s/%s/root/%s D 0 0755 0 0\\n' "${libc}" "${arch}" "${rel}" >> "${pseudo}"
         ;;
       f)
-        printf '/libc/%s/%s/root/%s l %s/root/%s\\n' "$${libc}" "$${arch}" "$${rel}" "$${repo_root}" "$${rel}" >> "$${pseudo}"
+        printf '/libc/%s/%s/root/%s l %s/root/%s\\n' "${libc}" "${arch}" "${rel}" "${repo_root}" "${rel}" >> "${pseudo}"
         ;;
       s)
-        printf '/libc/%s/%s/root/%s S 0 0777 0 0 %s\\n' "$${libc}" "$${arch}" "$${rel}" "$${target}" >> "$${pseudo}"
+        printf '/libc/%s/%s/root/%s S 0 0777 0 0 %s\\n' "${libc}" "${arch}" "${rel}" "${target}" >> "${pseudo}"
         ;;
     esac
-  done < "$${entries}"
+  done < "${entries}"
 }
 
 append_shell_runtime() {
-  local entries="$$1"
-  local shell="$$2"
-  local arch="$$3"
-  local manifest="$$4"
-  local repo_root
-  repo_root="$$(dirname "$${manifest}")"
+  entries="$1"
+  shell="$2"
+  arch="$3"
+  manifest="$4"
+  repo_root="${manifest%/*}"
 
-  printf '/shell/%s/%s/runtime_manifest.json l %s\\n' "$${shell}" "$${arch}" "$${manifest}" >> "$${pseudo}"
-  while IFS="$$(printf '\\t')" read -r kind rel target; do
-    case "$${kind}" in
+  printf '/shell/%s/%s/runtime_manifest.json l %s\\n' "${shell}" "${arch}" "${manifest}" >> "${pseudo}"
+  while IFS="$(printf '\\t')" read -r kind rel target; do
+    case "${kind}" in
       d)
-        printf '/shell/%s/%s/root/%s D 0 0755 0 0\\n' "$${shell}" "$${arch}" "$${rel}" >> "$${pseudo}"
+        printf '/shell/%s/%s/root/%s D 0 0755 0 0\\n' "${shell}" "${arch}" "${rel}" >> "${pseudo}"
         ;;
       f)
-        printf '/shell/%s/%s/root/%s l %s/root/%s\\n' "$${shell}" "$${arch}" "$${rel}" "$${repo_root}" "$${rel}" >> "$${pseudo}"
+        printf '/shell/%s/%s/root/%s l %s/root/%s\\n' "${shell}" "${arch}" "${rel}" "${repo_root}" "${rel}" >> "${pseudo}"
         ;;
       s)
-        printf '/shell/%s/%s/root/%s S 0 0777 0 0 %s\\n' "$${shell}" "$${arch}" "$${rel}" "$${target}" >> "$${pseudo}"
+        printf '/shell/%s/%s/root/%s S 0 0777 0 0 %s\\n' "${shell}" "${arch}" "${rel}" "${target}" >> "${pseudo}"
         ;;
     esac
-  done < "$${entries}"
+  done < "${entries}"
 }
 
 @APPEND_RUNTIME_CALLS@
 @APPEND_SHELL_RUNTIME_CALLS@
 
-"$(execpath @squashfs-tools//:mksquashfs)" - "$@" \\
-  -pf "$${pseudo}" \\
-  -pd 'D 0 0755 0 0' \\
-  -noappend \\
-  -no-recovery \\
-  -no-progress \\
-  -quiet \\
-  -comp zstd \\
-  -Xcompression-level 22 \\
-  -repro-time 0 \\
-  -all-root \\
-  -no-xattrs \\
+"${mksquashfs}" - "${output}" \
+  -pf "${pseudo}" \
+  -pd 'D 0 0755 0 0' \
+  -noappend \
+  -no-recovery \
+  -no-progress \
+  -quiet \
+  -comp zstd \
+  -Xcompression-level 22 \
+  -repro-time 0 \
+  -all-root \
+  -no-xattrs \
   -no-exports
 """
 
+def _runtime_squashfs_action_impl(ctx):
+    args = ctx.actions.args()
+    for value in ctx.attr.args:
+        args.add(ctx.expand_location(value, targets = ctx.attr.srcs))
+
+    ctx.actions.run(
+        arguments = [args],
+        env = {
+            "MKSQUASHFS": ctx.executable.mksquashfs.path,
+            "OUTPUT": ctx.outputs.out.path,
+        },
+        executable = ctx.executable.runner,
+        inputs = ctx.files.srcs,
+        outputs = [ctx.outputs.out],
+        tools = [ctx.attr.mksquashfs[DefaultInfo].files_to_run],
+    )
+
+_runtime_squashfs_action = rule(
+    implementation = _runtime_squashfs_action_impl,
+    attrs = {
+        "args": attr.string_list(),
+        "mksquashfs": attr.label(cfg = "exec", executable = True, mandatory = True),
+        "out": attr.output(mandatory = True),
+        "runner": attr.label(cfg = "exec", executable = True, mandatory = True),
+        "srcs": attr.label_list(allow_files = True),
+    },
+)
+
 def runtime_squashfs(name, arch, runtimes, out, shell_runtimes = [], visibility = None):
     srcs = []
+    args = []
     append_calls = []
     for repo, libc in runtimes:
         entries = "@%s//:squashfs_entries.txt" % repo
@@ -84,10 +115,14 @@ def runtime_squashfs(name, arch, runtimes, out, shell_runtimes = [], visibility 
             entries,
             "@%s//:tree" % repo,
         ])
-        append_calls.append(
-            'append_runtime "$(location %s)" "%s" "%s" "$(location %s)"' %
-            (entries, libc, arch, manifest),
-        )
+        args.extend([
+            "$(location %s)" % entries,
+            "$(location %s)" % manifest,
+        ])
+        append_calls.extend([
+            'append_runtime "$1" "%s" "%s" "$2"' % (libc, arch),
+            "shift 2",
+        ])
 
     append_shell_calls = []
     for repo, shell in shell_runtimes:
@@ -98,22 +133,40 @@ def runtime_squashfs(name, arch, runtimes, out, shell_runtimes = [], visibility 
             entries,
             "@%s//:tree" % repo,
         ])
-        append_shell_calls.append(
-            'append_shell_runtime "$(location %s)" "%s" "%s" "$(location %s)"' %
-            (entries, shell, arch, manifest),
-        )
+        args.extend([
+            "$(location %s)" % entries,
+            "$(location %s)" % manifest,
+        ])
+        append_shell_calls.extend([
+            'append_shell_runtime "$1" "%s" "%s" "$2"' % (shell, arch),
+            "shift 2",
+        ])
 
-    native.genrule(
-        name = name,
-        srcs = srcs,
-        outs = [out],
-        cmd = _RUNTIME_SQUASHFS_CMD.replace("@PSEUDO_NAME@", name).replace(
+    write_file(
+        name = name + "_script",
+        out = name + ".sh",
+        content = _RUNTIME_SQUASHFS_SCRIPT.replace(
             "@APPEND_RUNTIME_CALLS@",
             "\n".join(append_calls),
         ).replace(
             "@APPEND_SHELL_RUNTIME_CALLS@",
             "\n".join(append_shell_calls),
-        ),
-        tools = ["@squashfs-tools//:mksquashfs"],
+        ).splitlines(),
+        is_executable = True,
+    )
+
+    sh_binary(
+        name = name + "_runner",
+        srcs = [":" + name + "_script"],
+        use_bash_launcher = False,
+    )
+
+    _runtime_squashfs_action(
+        name = name,
+        args = args,
+        mksquashfs = "@squashfs-tools//:mksquashfs",
+        out = out,
+        runner = ":" + name + "_runner",
+        srcs = srcs,
         visibility = visibility,
     )

--- a/third_party/e2fsprogs/BUILD.bazel
+++ b/third_party/e2fsprogs/BUILD.bazel
@@ -1,9 +1,1 @@
-load("@bazel_lib//lib:transitions.bzl", "platform_transition_binary")
-
-platform_transition_binary(
-    name = "mkfs_ext4_linux_aarch64",
-    basename = "mkfs.ext4",
-    binary = "@e2fsprogs//:mkfs_ext4.stripped",
-    target_platform = "@llvm//platforms:linux_arm64_musl",
-    visibility = ["//visibility:public"],
-)
+exports_files(["e2fsprogs.BUILD.bazel"])

--- a/third_party/e2fsprogs/e2fsprogs.BUILD.bazel
+++ b/third_party/e2fsprogs/e2fsprogs.BUILD.bazel
@@ -1,6 +1,9 @@
 load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_lib//lib:expand_template.bzl", "expand_template")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@actiond//tools:e2fsprogs_generate.bzl", "e2fsprogs_generate")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -218,6 +221,40 @@ expand_template(
     template = "lib/uuid/uuid_types.h.in",
 )
 
+write_file(
+    name = "generate_script",
+    out = "generate.sh",
+    content = [
+        "#!/bin/sh",
+        "set -eu",
+        "mode=\"$1\"",
+        "output=\"$2\"",
+        "gawk=\"$3\"",
+        "case \"${mode}\" in",
+        "  crc32c-table)",
+        "    \"$4\" > \"${output}\"",
+        "    ;;",
+        "  error-table)",
+        "    \"${gawk}\" -f \"$4\" \"outfile=${output}\" \"outfn=$5\" \"$6\"",
+        "    ;;",
+        "  default-profile)",
+        "    \"${gawk}\" -f \"$4\" < \"$5\" > \"${output}\"",
+        "    ;;",
+        "  *)",
+        "    echo \"unknown generation mode: ${mode}\" >&2",
+        "    exit 2",
+        "    ;;",
+        "esac",
+    ],
+    is_executable = True,
+)
+
+sh_binary(
+    name = "generate",
+    srcs = [":generate_script"],
+    use_bash_launcher = False,
+)
+
 cc_binary(
     name = "gen_crc32ctable",
     srcs = [
@@ -227,11 +264,12 @@ cc_binary(
     includes = ["lib/ext2fs"],
 )
 
-genrule(
+e2fsprogs_generate(
     name = "crc32c_table_h",
-    outs = ["generated/lib/ext2fs/crc32c_table.h"],
-    cmd = "$(execpath :gen_crc32ctable) > $@",
-    tools = [":gen_crc32ctable"],
+    crc32c_generator = ":gen_crc32ctable",
+    mode = "crc32c-table",
+    out = "generated/lib/ext2fs/crc32c_table.h",
+    runner = ":generate",
 )
 
 expand_template(
@@ -243,54 +281,53 @@ expand_template(
     template = "lib/ext2fs/ext2_err.et.in",
 )
 
-genrule(
+e2fsprogs_generate(
     name = "ext2_err_h",
-    srcs = [
-        ":ext2_err_et",
-        "lib/et/et_h.awk",
-    ],
-    outs = ["generated/lib/ext2fs/ext2_err.h"],
-    cmd = "awk -f $(location lib/et/et_h.awk) 'outfile=$@' 'outfn=ext2_err.h' $(location :ext2_err_et)",
+    awk = "lib/et/et_h.awk",
+    input = ":ext2_err_et",
+    mode = "error-table",
+    out = "generated/lib/ext2fs/ext2_err.h",
+    output_function = "ext2_err.h",
+    runner = ":generate",
 )
 
-genrule(
+e2fsprogs_generate(
     name = "ext2_err_c",
-    srcs = [
-        ":ext2_err_et",
-        "lib/et/et_c.awk",
-    ],
-    outs = ["generated/lib/ext2fs/ext2_err.c"],
-    cmd = "awk -f $(location lib/et/et_c.awk) 'outfile=$@' 'outfn=ext2_err.c' $(location :ext2_err_et)",
+    awk = "lib/et/et_c.awk",
+    input = ":ext2_err_et",
+    mode = "error-table",
+    out = "generated/lib/ext2fs/ext2_err.c",
+    output_function = "ext2_err.c",
+    runner = ":generate",
 )
 
-genrule(
+e2fsprogs_generate(
     name = "prof_err_h",
-    srcs = [
-        "lib/et/et_h.awk",
-        "lib/support/prof_err.et",
-    ],
-    outs = ["generated/lib/support/prof_err.h"],
-    cmd = "awk -f $(location lib/et/et_h.awk) 'outfile=$@' 'outfn=prof_err.h' $(location lib/support/prof_err.et)",
+    awk = "lib/et/et_h.awk",
+    input = "lib/support/prof_err.et",
+    mode = "error-table",
+    out = "generated/lib/support/prof_err.h",
+    output_function = "prof_err.h",
+    runner = ":generate",
 )
 
-genrule(
+e2fsprogs_generate(
     name = "prof_err_c",
-    srcs = [
-        "lib/et/et_c.awk",
-        "lib/support/prof_err.et",
-    ],
-    outs = ["generated/lib/support/prof_err.c"],
-    cmd = "awk -f $(location lib/et/et_c.awk) 'outfile=$@' 'outfn=prof_err.c' $(location lib/support/prof_err.et)",
+    awk = "lib/et/et_c.awk",
+    input = "lib/support/prof_err.et",
+    mode = "error-table",
+    out = "generated/lib/support/prof_err.c",
+    output_function = "prof_err.c",
+    runner = ":generate",
 )
 
-genrule(
+e2fsprogs_generate(
     name = "default_profile_c",
-    srcs = [
-        "misc/mke2fs.conf.in",
-        "misc/profile-to-c.awk",
-    ],
-    outs = ["generated/misc/default_profile.c"],
-    cmd = "awk -f $(location misc/profile-to-c.awk) < $(location misc/mke2fs.conf.in) > $@",
+    awk = "misc/profile-to-c.awk",
+    input = "misc/mke2fs.conf.in",
+    mode = "default-profile",
+    out = "generated/misc/default_profile.c",
+    runner = ":generate",
 )
 
 cc_library(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -35,7 +35,7 @@ platform_transition_binary(
     name = "e2e_action_tool_linux_aarch64",
     basename = "e2e_action_tool_linux_aarch64",
     binary = ":e2e_action_tool",
-    target_platform = "//platforms:linux_aarch64",
+    target_platform = "//platforms:linux_aarch64_musl",
     visibility = ["//visibility:public"],
 )
 
@@ -43,7 +43,7 @@ platform_transition_binary(
     name = "e2e_action_tool_linux_x86_64",
     basename = "e2e_action_tool_linux_x86_64",
     binary = ":e2e_action_tool",
-    target_platform = "//platforms:linux_x86_64",
+    target_platform = "//platforms:linux_x86_64_musl",
     visibility = ["//visibility:public"],
 )
 

--- a/tools/e2e.sh
+++ b/tools/e2e.sh
@@ -171,10 +171,9 @@ run_stress_workspace() {
 
 run_build_checks() {
   run_bazel test //src:unit_tests
-  run_bazel build //cmd/linux_actiond_guest:linux-actiond-guest-aarch64
-  run_bazel build //vm:initramfs
+  run_bazel build //vm:initramfs_aarch64
   run_bazel build //runtimes:runtimes_squashfs
-  run_bazel build //vm:linux_kernel --nobuild
+  run_bazel build //vm:linux_kernel_aarch64 --nobuild
   run_bazel build //tools:e2e_action_tool_linux_aarch64 //tools:e2e_action_tool_linux_x86_64
   run_bazel build //...
   run_bazel test //...
@@ -253,12 +252,12 @@ run_vm_e2e() {
   else
     run_bazel build \
       //cmd/darwin-actiond \
-      //vm:linux_kernel_zst \
-      //vm:initramfs \
+      //vm:linux_kernel_aarch64_zst \
+      //vm:initramfs_aarch64 \
       //runtimes:runtimes_squashfs
     local kernel initramfs runtimes
-    kernel="$(bazel_output //vm:linux_kernel_zst)"
-    initramfs="$(bazel_output //vm:initramfs)"
+    kernel="$(bazel_output //vm:linux_kernel_aarch64_zst)"
+    initramfs="$(bazel_output //vm:initramfs_aarch64)"
     runtimes="$(bazel_output //runtimes:runtimes_squashfs)"
     server="$(bazel_output //cmd/darwin-actiond)"
     server_args+=(

--- a/tools/e2fsprogs_generate.bzl
+++ b/tools/e2fsprogs_generate.bzl
@@ -1,0 +1,56 @@
+"""Hermetic e2fsprogs source generation actions."""
+
+
+def _e2fsprogs_generate_impl(ctx):
+    args = ctx.actions.args()
+    args.add(ctx.attr.mode)
+    args.add(ctx.outputs.out)
+    args.add(ctx.executable._gawk)
+    if ctx.attr.mode == "crc32c-table":
+        args.add(ctx.executable.crc32c_generator)
+    elif ctx.attr.mode == "error-table":
+        args.add(ctx.file.awk)
+        args.add(ctx.attr.output_function)
+        args.add(ctx.file.input)
+    elif ctx.attr.mode == "default-profile":
+        args.add(ctx.file.awk)
+        args.add(ctx.file.input)
+    else:
+        fail("unsupported e2fsprogs generation mode: %s" % ctx.attr.mode)
+
+    inputs = []
+    if ctx.file.awk:
+        inputs.append(ctx.file.awk)
+    if ctx.file.input:
+        inputs.append(ctx.file.input)
+
+    tools = [ctx.attr._gawk[DefaultInfo].files_to_run]
+    if ctx.attr.crc32c_generator:
+        tools.append(ctx.attr.crc32c_generator[DefaultInfo].files_to_run)
+
+    ctx.actions.run(
+        arguments = [args],
+        executable = ctx.executable.runner,
+        inputs = inputs,
+        outputs = [ctx.outputs.out],
+        tools = tools,
+    )
+
+
+e2fsprogs_generate = rule(
+    implementation = _e2fsprogs_generate_impl,
+    attrs = {
+        "awk": attr.label(allow_single_file = True),
+        "crc32c_generator": attr.label(cfg = "exec", executable = True),
+        "_gawk": attr.label(
+            cfg = "exec",
+            default = Label("@gawk//:gawk"),
+            executable = True,
+        ),
+        "input": attr.label(allow_single_file = True),
+        "mode": attr.string(mandatory = True),
+        "out": attr.output(mandatory = True),
+        "output_function": attr.string(),
+        "runner": attr.label(cfg = "exec", executable = True, mandatory = True),
+    },
+)

--- a/vm/BUILD.bazel
+++ b/vm/BUILD.bazel
@@ -1,25 +1,36 @@
 load("@linux.bzl//:linux.bzl", "linux")
+load("@bazel_lib//lib:run_binary.bzl", "run_binary")
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 
-genrule(
-    name = "initramfs",
-    srcs = [
-        "//cmd/linux_actiond_guest:linux-actiond-guest-aarch64",
+run_binary(
+    name = "initramfs_target",
+    args = [
+        "$(location initramfs.cpio.zst)",
+        "$(location //cmd/linux_actiond_guest:linux-actiond-guest)",
+        "--file=$(location @e2fsprogs//:mkfs_ext4.stripped)=/sbin/mkfs.ext4",
     ],
     outs = ["initramfs.cpio.zst"],
-    cmd = "$(execpath //tools:initramfs_newc) $@ $(location //cmd/linux_actiond_guest:linux-actiond-guest-aarch64) --file=$(execpath //third_party/e2fsprogs:mkfs_ext4_linux_aarch64)=/sbin/mkfs.ext4",
-    tools = [
-        "//third_party/e2fsprogs:mkfs_ext4_linux_aarch64",
-        "//tools:initramfs_newc",
+    srcs = [
+        "//cmd/linux_actiond_guest:linux-actiond-guest",
+        "@e2fsprogs//:mkfs_ext4.stripped",
     ],
+    tags = ["manual"],
+    tool = "//tools:initramfs_newc",
+)
+
+platform_transition_filegroup(
+    name = "initramfs_aarch64",
+    srcs = [":initramfs_target"],
+    target_platform = "//platforms:linux_aarch64_musl",
     visibility = ["//visibility:public"],
 )
 
 linux(
-    name = "linux_kernel",
+    name = "linux_kernel_aarch64",
     compact_repos = {
-        "aarch64": "@actiond_vm_compact",
+        "aarch64": "@actiond_vm_aarch64_compact",
     },
-    config = "@actiond_vm_kconfig//:kconfig",
+    config = "@actiond_vm_aarch64_kconfig//:kconfig",
     config_mode = "allnoconfig",
     extra_kconfigs = {
         "//kernel/actiondfs:Kconfig": "fs/actiondfs",
@@ -30,11 +41,14 @@ linux(
     visibility = ["//visibility:public"],
 )
 
-genrule(
-    name = "linux_kernel_zst",
-    srcs = [":linux_kernel"],
+run_binary(
+    name = "linux_kernel_aarch64_zst",
+    args = [
+        "$(location :linux_kernel_aarch64)",
+        "$(location Image.zst)",
+    ],
     outs = ["Image.zst"],
-    cmd = "$(execpath //tools:zstd_file) $(location :linux_kernel) $@",
-    tools = ["//tools:zstd_file"],
+    srcs = [":linux_kernel_aarch64"],
+    tool = "//tools:zstd_file",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Author: zbarsky-bot

Replace shell `genrule` commands for e2fsprogs, SquashFS, initramfs, and kernel compression with declared executable actions. The VM artifact targets now select explicit Linux musl platforms, and the existing aarch64 initramfs and kernel targets have architecture-specific names so another architecture can reuse the same actions without duplicating wrappers.

Validation: `bazel build --config=remote --jobs=4 @e2fsprogs//:crc32c_table_h @e2fsprogs//:ext2_err_h @e2fsprogs//:default_profile_c` and `bazel build --config=remote --jobs=4 //vm:initramfs_aarch64 //runtimes:runtimes_squashfs //vm:linux_kernel_aarch64_zst //cmd/darwin-actiond` pass. `bazel build //... --jobs=4` still fails in the macOS aarch64 kernel host-tool graph because `elfutils` cannot find `libintl.h`.
