### PR TITLE
Compress embedded VM assets

### DIFF
--- a/.github/workflows/build_release.sh
+++ b/.github/workflows/build_release.sh
@@ -5,6 +5,7 @@ artifact_dir="${1:-release}"
 artifact_dir="$(mkdir -p "${artifact_dir}" && cd "${artifact_dir}" && pwd)"
 bazel_flags=(
   --config=remote
+  --strip=always
 )
 
 if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,25 +44,25 @@ native Linux filesystem.
 
 ## Components
 
-`darwin-actiond` is the released macOS binary. Zig `@embedFile` includes the
-Linux kernel, initramfs, and ARM64 runtime SquashFS. At startup it materializes
-those bytes under `--root`, inflates the kernel and initramfs to raw boot files,
-starts the VM with Virtualization.framework, and bridges public gRPC traffic to
-the guest.
+`darwin-actiond` is the released macOS binary. Zig `@embedFile` includes
+zstd level 22 frames containing the Linux kernel, initramfs, and ARM64 runtime
+SquashFS. At startup it expands those frames under `--root`, starts the VM with
+Virtualization.framework, and bridges public gRPC traffic to the guest.
 
 `windows-actiond` is released for ARM64 and x86_64. Zig `@embedFile` includes
-the matching Linux kernel, initramfs, and runtime SquashFS. At startup it
-materializes those bytes under `--root`, wraps the runtime and CAS as fixed VHD
-files, and starts the VM with Host Compute System.
+zstd level 22 frames containing the matching Linux kernel, initramfs, and
+runtime SquashFS. At startup it expands those frames under `--root`, wraps the
+runtime and CAS as fixed VHD files, and starts the VM with Host Compute System.
 
-`linux-actiond` is released for ARM64 and x86_64. Zig `@embedFile` includes the
-matching Linux kernel, initramfs, runtime SquashFS, and QEMU executable selected
-by the `rules_qemu` target toolchain. The x86_64 release also includes
-`qboot.rom`; QEMU `virt` direct kernel boot on ARM64 does not require firmware.
-`linux-actiond` creates sealed memfds for QEMU and every immutable embedded VM
-artifact, then executes QEMU with `execveat`. Only the persistent guest-owned
-CAS image is stored under `--root`. QEMU uses KVM and host CPU passthrough. The
-persistent CAS image uses `cache=none`, `aio=io_uring`, one IOThread, and one
+`linux-actiond` is released for ARM64 and x86_64. Zig `@embedFile` includes
+zstd level 22 frames containing the matching Linux kernel, initramfs, runtime
+SquashFS, and QEMU executable selected by the `rules_qemu` target toolchain.
+The x86_64 release also includes compressed `qboot.rom`; QEMU `virt` direct
+kernel boot on ARM64 does not require firmware. `linux-actiond` expands every
+frame into a sealed memfd, then executes QEMU with `execveat`. Only the
+persistent guest-owned CAS image is stored under `--root`. QEMU uses KVM and
+host CPU passthrough. The persistent CAS image uses `cache=none`,
+`aio=io_uring`, one IOThread, and one
 virtio-blk queue per vCPU up to four queues.
 
 `linux-actiond-guest` lives in the initramfs. It runs as guest init, mounts the

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Windows, and Linux it starts a small Linux VM and runs Bazel actions inside
 that VM, so the host can act like a local Linux remote-execution worker.
 
 The macOS ARM64, Windows ARM64/x86_64, and Linux ARM64/x86_64 releases include
-the matching VM kernel, initramfs, and Linux runtime image.
+zstd level 22 frames containing the matching VM kernel, initramfs, and Linux
+runtime image.
 
 ## Why Use It?
 
@@ -61,11 +62,12 @@ Windows requires Hyper-V. `windows-actiond` wraps the runtime SquashFS and
 guest-owned ext4 CAS in fixed VHD files. The default VHD paths are under
 `--root`; `--cas-image` can select another CAS VHD path.
 
-The Linux releases embed the matching QEMU executable from `rules_qemu`. The
-x86_64 release also embeds `qboot.rom`. `linux-actiond` passes QEMU, the Linux
-kernel, the initramfs, the runtime SquashFS, and `qboot.rom` through sealed
-memfds. The guest-owned CAS remains a persistent ext4 file under `--root`. The
-QEMU process uses KVM, host CPU passthrough, and `io_uring` for the CAS file.
+The Linux releases embed zstd level 22 frames containing the matching QEMU
+executable from `rules_qemu` and, on x86_64, `qboot.rom`. `linux-actiond`
+expands QEMU, the Linux kernel, the initramfs, the runtime SquashFS, and
+`qboot.rom` into sealed memfds. The guest-owned CAS remains a persistent ext4
+file under `--root`. The QEMU process uses KVM, host CPU passthrough, and
+`io_uring` for the CAS file.
 The host kernel must support `io_uring`. `linux-actiond` requires read/write
 access to `/dev/kvm` and `/dev/vhost-vsock`:
 

--- a/cmd/darwin-actiond/BUILD.bazel
+++ b/cmd/darwin-actiond/BUILD.bazel
@@ -33,7 +33,7 @@ zig_binary(
 zig_embedded_assets(
     name = "embedded_assets",
     initramfs = "//vm:initramfs_aarch64",
-    kernel = "//vm:linux_kernel.image_zst",
+    kernel = "//vm:linux_kernel.image",
     runtime_image = "//runtimes:runtimes_squashfs_aarch64",
 )
 

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -53,6 +53,7 @@ zig_library(
         "vsock.zig",
         "windows_hcs.zig",
         "windows_vm_host.zig",
+        "zstd.zig",
     ],
     import_name = "actiond",
     main = "root.zig",
@@ -103,6 +104,7 @@ zig_test(
         "vsock.zig",
         "windows_hcs.zig",
         "windows_vm_host.zig",
+        "zstd.zig",
     ],
     main = "root.zig",
     deps = [

--- a/src/linux_vm_host.zig
+++ b/src/linux_vm_host.zig
@@ -30,7 +30,7 @@ pub fn serve(
     prepared.boot_initramfs_path = prepared.owned_boot_initramfs_path orelse prepared.assets.initramfs;
 
     const expects_firmware = std.mem.eql(u8, embedded_qemu.target_arch, "x86_64");
-    if ((embedded_qemu.firmware != null) != expects_firmware) return error.InvalidQemuAssets;
+    if ((embedded_qemu.firmware_zstd != null) != expects_firmware) return error.InvalidQemuAssets;
 
     std.log.info("starting QEMU VM kernel={s} initramfs={s} runtimes={s} cas={s}", .{
         prepared.boot_kernel_path,
@@ -46,7 +46,7 @@ pub fn serve(
         .initramfs_path = prepared.boot_initramfs_path,
         .runtime_image_path = prepared.assets.runtime_image,
         .cas_image_path = prepared.cas_image_path,
-        .firmware_path = if (embedded_qemu.firmware != null) qemu_vm.embedded_firmware_path else null,
+        .firmware_path = if (embedded_qemu.firmware_zstd != null) qemu_vm.embedded_firmware_path else null,
         .format_cas_image = prepared.format_cas_image,
         .memory_mib = options.memory_mib,
         .cpu_count = options.cpus,

--- a/src/qemu_vm.zig
+++ b/src/qemu_vm.zig
@@ -2,11 +2,13 @@ const builtin = @import("builtin");
 const std = @import("std");
 const control_transport_fd = @import("control_transport_fd.zig");
 const vsock = @import("vsock.zig");
+const zstd = @import("zstd.zig");
 
 const linux = std.os.linux;
 const mfd_exec = 0x0010;
 const max_vcpus = 64;
 const max_cas_queues = 4;
+const max_embedded_asset_bytes = 512 * 1024 * 1024;
 
 pub const fexec_argument = "--actiond-internal-fexec-qemu";
 pub const embedded_kernel_path = "actiond-internal-embedded-kernel";
@@ -247,7 +249,9 @@ pub fn fexecEmbedded(
     };
     const file: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = false } };
     defer file.close(io);
-    try file.writePositionalAll(io, embedded_qemu.qemu_system, 0);
+    const qemu_system = try zstd.decompressAlloc(allocator, embedded_qemu.qemu_system_zstd, max_embedded_asset_bytes);
+    defer allocator.free(qemu_system);
+    try file.writePositionalAll(io, qemu_system, 0);
     try file.setPermissions(io, .executable_file);
 
     const seals = linux.F.SEAL_SEAL | linux.F.SEAL_SHRINK | linux.F.SEAL_GROW | linux.F.SEAL_WRITE;
@@ -265,7 +269,7 @@ pub fn fexecEmbedded(
             continue;
         };
         if (inherited_fd_count == inherited_fds.len) return error.TooManyEmbeddedAssets;
-        const inherited_fd = try createSealedMemfd(io, asset.name, asset.bytes);
+        const inherited_fd = try createSealedZstdMemfd(io, allocator, asset.name, asset.bytes);
         inherited_fds[inherited_fd_count] = inherited_fd;
         inherited_fd_count += 1;
         const path = try std.fmt.allocPrintSentinel(allocator, "/proc/self/fd/{d}", .{inherited_fd}, 0);
@@ -288,13 +292,13 @@ const EmbeddedAsset = struct {
 };
 
 fn embeddedAsset(arg: []const u8, comptime embedded_assets: type, comptime embedded_qemu: type) !?EmbeddedAsset {
-    if (std.mem.indexOf(u8, arg, embedded_kernel_path) != null) return .{ .marker = embedded_kernel_path, .name = "actiond-kernel", .bytes = embedded_assets.kernel };
-    if (std.mem.indexOf(u8, arg, embedded_initramfs_path) != null) return .{ .marker = embedded_initramfs_path, .name = "actiond-initramfs", .bytes = embedded_assets.initramfs };
-    if (std.mem.indexOf(u8, arg, embedded_runtime_image_path) != null) return .{ .marker = embedded_runtime_image_path, .name = "actiond-runtimes", .bytes = embedded_assets.runtime_image };
+    if (std.mem.indexOf(u8, arg, embedded_kernel_path) != null) return .{ .marker = embedded_kernel_path, .name = "actiond-kernel", .bytes = embedded_assets.kernel_zstd };
+    if (std.mem.indexOf(u8, arg, embedded_initramfs_path) != null) return .{ .marker = embedded_initramfs_path, .name = "actiond-initramfs", .bytes = embedded_assets.initramfs_zstd };
+    if (std.mem.indexOf(u8, arg, embedded_runtime_image_path) != null) return .{ .marker = embedded_runtime_image_path, .name = "actiond-runtimes", .bytes = embedded_assets.runtime_image_zstd };
     if (std.mem.indexOf(u8, arg, embedded_firmware_path) != null) return .{
         .marker = embedded_firmware_path,
         .name = "actiond-firmware",
-        .bytes = embedded_qemu.firmware orelse return error.InvalidQemuAssets,
+        .bytes = embedded_qemu.firmware_zstd orelse return error.InvalidQemuAssets,
     };
     return null;
 }
@@ -316,10 +320,17 @@ fn replaceEmbeddedAssetPath(
     return replaced;
 }
 
-fn createSealedMemfd(io: std.Io, name: []const u8, bytes: []const u8) !std.posix.fd_t {
+fn createSealedZstdMemfd(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    compressed: []const u8,
+) !std.posix.fd_t {
     const fd = try std.posix.memfd_create(name, linux.MFD.CLOEXEC | linux.MFD.ALLOW_SEALING);
     errdefer closeFd(fd);
     const file: std.Io.File = .{ .handle = fd, .flags = .{ .nonblocking = false } };
+    const bytes = try zstd.decompressAlloc(allocator, compressed, max_embedded_asset_bytes);
+    defer allocator.free(bytes);
     try file.writePositionalAll(io, bytes, 0);
 
     const seals = linux.F.SEAL_SEAL | linux.F.SEAL_SHRINK | linux.F.SEAL_GROW | linux.F.SEAL_WRITE;
@@ -450,12 +461,12 @@ test "driveArg uses io_uring for the CAS image" {
 
 test "embedded asset arguments select embedded bytes" {
     const assets = struct {
-        const kernel = "kernel";
-        const initramfs = "initramfs";
-        const runtime_image = "runtimes";
+        const kernel_zstd = "kernel";
+        const initramfs_zstd = "initramfs";
+        const runtime_image_zstd = "runtimes";
     };
     const qemu = struct {
-        const firmware: ?[]const u8 = "qboot";
+        const firmware_zstd: ?[]const u8 = "qboot";
     };
 
     try std.testing.expectEqualStrings("kernel", (try embeddedAsset(embedded_kernel_path, assets, qemu)).?.bytes);
@@ -470,7 +481,7 @@ test "embedded asset arguments select embedded bytes" {
     try std.testing.expect((try embeddedAsset("/tmp/kernel", assets, qemu)) == null);
 
     const qemu_without_firmware = struct {
-        const firmware: ?[]const u8 = null;
+        const firmware_zstd: ?[]const u8 = null;
     };
     try std.testing.expectError(
         error.InvalidQemuAssets,

--- a/src/root.zig
+++ b/src/root.zig
@@ -32,6 +32,7 @@ pub const version = @import("version.zig");
 pub const vm_host = @import("vm_host.zig");
 pub const vsock = @import("vsock.zig");
 pub const windows_vm_host = @import("windows_vm_host.zig");
+pub const zstd = @import("zstd.zig");
 
 test {
     _ = action_executor;
@@ -68,4 +69,5 @@ test {
     _ = vm_host;
     _ = vsock;
     _ = windows_vm_host;
+    _ = zstd;
 }

--- a/src/vm_host.zig
+++ b/src/vm_host.zig
@@ -3,13 +3,14 @@ const std = @import("std");
 const control_protocol = @import("control_protocol.zig");
 const control_transport_fd = @import("control_transport_fd.zig");
 const grpc_vsock_bridge = @import("grpc_vsock_bridge.zig");
+const zstd = @import("zstd.zig");
 const zstd_test = if (builtin.is_test) @import("c") else struct {};
 
 const max_compressed_initramfs_bytes = 128 * 1024 * 1024;
 const max_raw_initramfs_bytes = 512 * 1024 * 1024;
 const max_compressed_kernel_bytes = 128 * 1024 * 1024;
 const max_raw_kernel_bytes = 512 * 1024 * 1024;
-const zstd_magic = [_]u8{ 0x28, 0xb5, 0x2f, 0xfd };
+const max_raw_runtime_image_bytes = 2 * 1024 * 1024 * 1024;
 var next_embedded_asset_temp_id = std.atomic.Value(u64).init(0);
 
 pub const ResolvedAssets = struct {
@@ -99,22 +100,35 @@ pub fn resolveAssets(
     if (options.kernel) |path| {
         resolved.kernel = path;
     } else {
-        resolved.owned_kernel = try materializeEmbeddedAsset(io, allocator, root_dir, "linux_kernel", embedded.kernel);
+        resolved.owned_kernel = try materializeEmbeddedZstdAsset(io, allocator, root_dir, "linux_kernel", embedded.kernel_zstd, max_raw_kernel_bytes);
         resolved.kernel = resolved.owned_kernel.?;
     }
     if (options.initramfs) |path| {
         resolved.initramfs = path;
     } else {
-        resolved.owned_initramfs = try materializeEmbeddedAsset(io, allocator, root_dir, "initramfs.cpio.zst", embedded.initramfs);
+        resolved.owned_initramfs = try materializeEmbeddedZstdAsset(io, allocator, root_dir, "initramfs.cpio", embedded.initramfs_zstd, max_raw_initramfs_bytes);
         resolved.initramfs = resolved.owned_initramfs.?;
     }
     if (options.runtime_image) |path| {
         resolved.runtime_image = path;
     } else {
-        resolved.owned_runtime_image = try materializeEmbeddedAsset(io, allocator, root_dir, "runtimes.sqfs", embedded.runtime_image);
+        resolved.owned_runtime_image = try materializeEmbeddedZstdAsset(io, allocator, root_dir, "runtimes.sqfs", embedded.runtime_image_zstd, max_raw_runtime_image_bytes);
         resolved.runtime_image = resolved.owned_runtime_image.?;
     }
     return resolved;
+}
+
+fn materializeEmbeddedZstdAsset(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    root_dir: std.Io.Dir,
+    name: []const u8,
+    compressed: []const u8,
+    max_raw_bytes: u64,
+) ![]u8 {
+    const raw = try zstd.decompressAlloc(allocator, compressed, max_raw_bytes);
+    defer allocator.free(raw);
+    return materializeEmbeddedAsset(io, allocator, root_dir, name, raw);
 }
 
 fn materializeEmbeddedAsset(
@@ -351,7 +365,7 @@ fn prepareZstdBootFile(
     );
     defer allocator.free(compressed);
 
-    if (!isZstdFrame(compressed)) {
+    if (!zstd.isFrame(compressed)) {
         if (std.mem.endsWith(u8, path, ".zst")) return error.InvalidCompressedBootArtifact;
         return null;
     }
@@ -371,7 +385,11 @@ fn prepareZstdBootFile(
         else => return err,
     }
 
-    const raw = try decompressZstdAlloc(allocator, compressed, max_raw_bytes);
+    const raw = zstd.decompressAlloc(allocator, compressed, max_raw_bytes) catch |err| switch (err) {
+        error.InvalidZstdFrame => return error.InvalidCompressedBootArtifact,
+        error.UnknownZstdContentSize => return error.UnknownCompressedBootArtifactSize,
+        else => |e| return e,
+    };
     defer allocator.free(raw);
 
     var file = try root_dir.createFile(io, output_rel, .{ .truncate = true });
@@ -383,36 +401,6 @@ fn prepareZstdBootFile(
 
     return try absoluteSubPath(io, allocator, root_dir, output_rel);
 }
-
-fn decompressZstdAlloc(allocator: std.mem.Allocator, compressed: []const u8, max_raw_bytes: u64) ![]u8 {
-    const content_size = ZSTD_getFrameContentSize(compressed.ptr, compressed.len);
-    if (content_size == zstdContentSizeError()) return error.InvalidCompressedBootArtifact;
-    if (content_size == zstdContentSizeUnknown()) return error.UnknownCompressedBootArtifactSize;
-    if (content_size > max_raw_bytes) return error.FileTooBig;
-
-    const raw = try allocator.alloc(u8, @intCast(content_size));
-    errdefer allocator.free(raw);
-    const actual_size = ZSTD_decompress(raw.ptr, raw.len, compressed.ptr, compressed.len);
-    if (ZSTD_isError(actual_size) != 0) return error.InvalidCompressedBootArtifact;
-    if (actual_size != raw.len) return error.InvalidCompressedBootArtifact;
-    return raw;
-}
-
-fn zstdContentSizeUnknown() c_ulonglong {
-    return std.math.maxInt(c_ulonglong);
-}
-
-fn zstdContentSizeError() c_ulonglong {
-    return std.math.maxInt(c_ulonglong) - 1;
-}
-
-fn isZstdFrame(bytes: []const u8) bool {
-    return bytes.len >= zstd_magic.len and std.mem.eql(u8, bytes[0..zstd_magic.len], &zstd_magic);
-}
-
-extern fn ZSTD_getFrameContentSize(src: *const anyopaque, src_size: usize) c_ulonglong;
-extern fn ZSTD_decompress(dst: *anyopaque, dst_capacity: usize, src: *const anyopaque, compressed_size: usize) usize;
-extern fn ZSTD_isError(code: usize) c_uint;
 
 pub fn absolutePath(io: std.Io, allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     if (std.fs.path.isAbsolute(path)) {
@@ -589,14 +577,35 @@ test "materializeEmbeddedAsset replaces corrupt cached bytes" {
     try std.testing.expectEqualStrings("payload", bytes);
 }
 
+test "materializeEmbeddedZstdAsset writes decompressed bytes" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const compressed = try compressZstdForTest(std.testing.allocator, "payload");
+    defer std.testing.allocator.free(compressed);
+    const path = try materializeEmbeddedZstdAsset(
+        std.testing.io,
+        std.testing.allocator,
+        tmp.dir,
+        "kernel",
+        compressed,
+        1024,
+    );
+    defer std.testing.allocator.free(path);
+
+    const bytes = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, path, std.testing.allocator, .limited(1024));
+    defer std.testing.allocator.free(bytes);
+    try std.testing.expectEqualStrings("payload", bytes);
+}
+
 test "resolveAssets preserves explicit paths" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
     const embedded = struct {
-        const kernel = "embedded kernel";
-        const initramfs = "embedded initramfs";
-        const runtime_image = "embedded runtimes";
+        const kernel_zstd = "embedded kernel";
+        const initramfs_zstd = "embedded initramfs";
+        const runtime_image_zstd = "embedded runtimes";
     };
 
     var resolved = try resolveAssets(std.testing.io, std.testing.allocator, tmp.dir, .{
@@ -659,8 +668,8 @@ test "prepareBootKernel inflates zstd payloads without relying on filename suffi
 }
 
 test "isZstdFrame detects zstd magic" {
-    try std.testing.expect(isZstdFrame(&zstd_magic));
-    try std.testing.expect(!isZstdFrame("not zstd"));
+    try std.testing.expect(zstd.isFrame(&.{ 0x28, 0xb5, 0x2f, 0xfd }));
+    try std.testing.expect(!zstd.isFrame("not zstd"));
 }
 
 test "decompressZstdAlloc inflates libzstd frames" {
@@ -668,7 +677,7 @@ test "decompressZstdAlloc inflates libzstd frames" {
     const compressed = try compressZstdForTest(std.testing.allocator, plain);
     defer std.testing.allocator.free(compressed);
 
-    const decompressed = try decompressZstdAlloc(std.testing.allocator, compressed, max_raw_initramfs_bytes);
+    const decompressed = try zstd.decompressAlloc(std.testing.allocator, compressed, max_raw_initramfs_bytes);
     defer std.testing.allocator.free(decompressed);
     try std.testing.expectEqualStrings(plain, decompressed);
 }

--- a/src/zstd.zig
+++ b/src/zstd.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+
+const magic = [_]u8{ 0x28, 0xb5, 0x2f, 0xfd };
+
+pub fn decompressAlloc(
+    allocator: std.mem.Allocator,
+    compressed: []const u8,
+    max_raw_bytes: u64,
+) ![]u8 {
+    const content_size = ZSTD_getFrameContentSize(compressed.ptr, compressed.len);
+    if (content_size == contentSizeError()) return error.InvalidZstdFrame;
+    if (content_size == contentSizeUnknown()) return error.UnknownZstdContentSize;
+    if (content_size > max_raw_bytes) return error.FileTooBig;
+
+    const raw = try allocator.alloc(u8, @intCast(content_size));
+    errdefer allocator.free(raw);
+    const actual_size = ZSTD_decompress(raw.ptr, raw.len, compressed.ptr, compressed.len);
+    if (ZSTD_isError(actual_size) != 0 or actual_size != raw.len) return error.InvalidZstdFrame;
+    return raw;
+}
+
+pub fn isFrame(bytes: []const u8) bool {
+    return bytes.len >= magic.len and std.mem.eql(u8, bytes[0..magic.len], &magic);
+}
+
+fn contentSizeUnknown() c_ulonglong {
+    return std.math.maxInt(c_ulonglong);
+}
+
+fn contentSizeError() c_ulonglong {
+    return std.math.maxInt(c_ulonglong) - 1;
+}
+
+extern fn ZSTD_getFrameContentSize(src: *const anyopaque, src_size: usize) c_ulonglong;
+extern fn ZSTD_decompress(dst: *anyopaque, dst_capacity: usize, src: *const anyopaque, compressed_size: usize) usize;
+extern fn ZSTD_isError(code: usize) c_uint;

--- a/tools/zig_embedded_assets.bzl
+++ b/tools/zig_embedded_assets.bzl
@@ -1,4 +1,5 @@
 load("@rules_zig//zig:defs.bzl", "zig_library")
+load("//tools:zstd.bzl", "zstd_compress", "zstd_tool_attr")
 
 def _asset_file(target, name):
     files = target[DefaultInfo].files.to_list()
@@ -16,10 +17,10 @@ def _zig_embedded_assets_source_impl(ctx):
         ("runtime_image", ctx.attr.runtime_image),
     ]:
         asset = _asset_file(target, name)
-        staged = ctx.actions.declare_file(ctx.label.name + "." + name)
-        ctx.actions.symlink(output = staged, target_file = asset)
-        embedded.append(staged)
-        lines.append('pub const %s = @embedFile("%s");' % (name, staged.basename))
+        compressed = ctx.actions.declare_file(ctx.label.name + "." + name + ".zst")
+        zstd_compress(ctx, asset, compressed)
+        embedded.append(compressed)
+        lines.append('pub const %s_zstd = @embedFile("%s");' % (name, compressed.basename))
     ctx.actions.write(out, "\n".join(lines) + "\n")
     return [
         DefaultInfo(files = depset([out])),
@@ -32,6 +33,7 @@ _zig_embedded_assets_source = rule(
         "initramfs": attr.label(mandatory = True),
         "kernel": attr.label(mandatory = True),
         "runtime_image": attr.label(mandatory = True),
+        "_zstd": zstd_tool_attr(),
     },
 )
 

--- a/tools/zig_embedded_qemu.bzl
+++ b/tools/zig_embedded_qemu.bzl
@@ -1,38 +1,41 @@
 load("@rules_zig//zig:defs.bzl", "zig_library")
+load("//tools:zstd.bzl", "zstd_compress", "zstd_tool_attr")
 
 _QEMU_TOOLCHAIN_TYPE = "@rules_qemu//qemu:target_toolchain_type"
 
 def _zig_embedded_qemu_source_impl(ctx):
     qemu = ctx.toolchains[_QEMU_TOOLCHAIN_TYPE]
-    qemu_system = ctx.actions.declare_file(ctx.label.name + ".qemu-system")
+    qemu_system = ctx.actions.declare_file(ctx.label.name + ".qemu-system.zst")
     source = ctx.actions.declare_file(ctx.label.name + ".zig")
-    ctx.actions.symlink(output = qemu_system, target_file = qemu.qemu_system)
+    zstd_compress(ctx, qemu.qemu_system, qemu_system)
     embedded = [qemu_system]
     lines = [
-        'pub const qemu_system = @embedFile("{}");'.format(qemu_system.basename),
+        'pub const qemu_system_zstd = @embedFile("{}");'.format(qemu_system.basename),
         'pub const qemu_system_name = "{}";'.format(qemu.qemu_system.basename),
         'pub const machine = "{}";'.format(qemu.machine),
         'pub const target_arch = "{}";'.format(qemu.target_arch),
     ]
 
     if qemu.system_target == "x86_64-softmmu":
-        firmware = ctx.actions.declare_file(ctx.label.name + ".qboot.rom")
+        firmware_raw = ctx.actions.declare_file(ctx.label.name + ".qboot.rom")
         ctx.actions.run_shell(
             arguments = [
                 qemu.system_data_anchor.path,
-                firmware.path,
+                firmware_raw.path,
             ],
             command = """
 set -eu
 cp "$1/qboot.rom" "$2"
 """,
             inputs = qemu.system_data_files,
-            outputs = [firmware],
+            outputs = [firmware_raw],
         )
+        firmware = ctx.actions.declare_file(ctx.label.name + ".qboot.rom.zst")
+        zstd_compress(ctx, firmware_raw, firmware)
         embedded.append(firmware)
-        lines.append('pub const firmware: ?[]const u8 = @embedFile("{}");'.format(firmware.basename))
+        lines.append('pub const firmware_zstd: ?[]const u8 = @embedFile("{}");'.format(firmware.basename))
     elif qemu.system_target == "aarch64-softmmu":
-        lines.append("pub const firmware: ?[]const u8 = null;")
+        lines.append("pub const firmware_zstd: ?[]const u8 = null;")
     else:
         fail("unsupported embedded QEMU system target: {}".format(qemu.system_target))
 
@@ -44,6 +47,7 @@ cp "$1/qboot.rom" "$2"
 
 _zig_embedded_qemu_source = rule(
     implementation = _zig_embedded_qemu_source_impl,
+    attrs = {"_zstd": zstd_tool_attr()},
     toolchains = [_QEMU_TOOLCHAIN_TYPE],
 )
 

--- a/tools/zstd.bzl
+++ b/tools/zstd.bzl
@@ -1,0 +1,23 @@
+def zstd_compress(ctx, source, output):
+    ctx.actions.run(
+        arguments = [
+            "-q",
+            "--ultra",
+            "-22",
+            "-f",
+            source.path,
+            "-o",
+            output.path,
+        ],
+        executable = ctx.executable._zstd,
+        inputs = [source],
+        mnemonic = "ZstdCompress",
+        outputs = [output],
+    )
+
+def zstd_tool_attr():
+    return attr.label(
+        cfg = "exec",
+        default = Label("@zstd//:zstd_cli"),
+        executable = True,
+    )

--- a/vm/BUILD.bazel
+++ b/vm/BUILD.bazel
@@ -1,18 +1,18 @@
-load("@linux.bzl//:linux.bzl", "linux")
 load("@bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@linux.bzl//:linux.bzl", "linux")
 
 run_binary(
     name = "initramfs",
-    args = [
-        "$(location initramfs.cpio.zst)",
-        "$(location //cmd/linux_actiond_guest:linux-actiond-guest)",
-        "--file=$(location @e2fsprogs//:mkfs_ext4.stripped)=/sbin/mkfs.ext4",
-    ],
-    outs = ["initramfs.cpio.zst"],
     srcs = [
         "//cmd/linux_actiond_guest:linux-actiond-guest",
         "@e2fsprogs//:mkfs_ext4.stripped",
+    ],
+    outs = ["initramfs.cpio"],
+    args = [
+        "$(location initramfs.cpio)",
+        "$(location //cmd/linux_actiond_guest:linux-actiond-guest)",
+        "--file=$(location @e2fsprogs//:mkfs_ext4.stripped)=/sbin/mkfs.ext4",
     ],
     tags = ["manual"],
     tool = "//tools:initramfs_newc",
@@ -35,13 +35,13 @@ platform_transition_filegroup(
 
 linux(
     name = "linux_kernel",
-    config = {
-        "aarch64": "@actiond_vm_aarch64_kconfig//:kconfig",
-        "x86_64": "@actiond_vm_x86_64_kconfig//:kconfig",
-    },
     compact_repos = {
         "aarch64": "@actiond_vm_aarch64_compact",
         "x86_64": "@actiond_vm_x86_64_compact",
+    },
+    config = {
+        "aarch64": "@actiond_vm_aarch64_kconfig//:kconfig",
+        "x86_64": "@actiond_vm_x86_64_kconfig//:kconfig",
     },
     config_mode = "allnoconfig",
     extra_kconfigs = {
@@ -54,6 +54,8 @@ linux(
 
 run_binary(
     name = "linux_kernel.image_zst",
+    srcs = [":linux_kernel.image"],
+    outs = ["Image.zst"],
     args = [
         "-q",
         "--ultra",
@@ -63,8 +65,6 @@ run_binary(
         "-o",
         "$(location :Image.zst)",
     ],
-    outs = ["Image.zst"],
-    srcs = [":linux_kernel.image"],
     tool = "@zstd//:zstd_cli",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Author: zbarsky-bot

The Windows and Linux releases embedded raw QEMU and Linux kernel files. These files accounted for 93–99% of each binary; Zig code and native libraries accounted for less than 1 MiB.

Published v0.0.5 artifacts are the baseline below. This change compresses every embedded VM asset with zstd level 22. Linux expands QEMU, the kernel, the initramfs, the runtime SquashFS, and `qboot.rom` directly into sealed memfds before `execveat`. macOS and Windows expand the same frames into the files already required by Virtualization.framework and Host Compute System. Release builds also request Bazel's final strip action.

| Release | Before | After | Change |
| --- | ---: | ---: | ---: |
| macOS ARM64 | 7.66 MiB | 7.61 MiB | -0.6% |
| Windows ARM64 | 11.97 MiB | 8.07 MiB | -32.6% |
| Windows x86_64 | 25.42 MiB | 10.78 MiB | -57.6% |
| Linux ARM64 | 46.29 MiB | 13.14 MiB | -71.6% |
| Linux x86_64 | 41.04 MiB | 15.17 MiB | -63.0% |

Validated with the five-target release build, `//src:unit_tests`, `//tools:initramfs_newc_tests`, and `ACTIOND_E2E_STANDALONE=1 ACTIOND_REPO_BAZEL_FLAGS=--config=remote tools/e2e.sh vm`. [GitHub Actions run 27499329309](https://github.com/hermeticbuild/actiond/actions/runs/27499329309) passed all five jobs. The Linux x86_64 smoke measured 0.817s VM startup, 260.931s actiond, and 249.374s Linux host with matching 2,079/1,998 process counts. Repository-wide build and test analysis still stop in the existing macOS `elfutils` dependency because `libintl.h` is unavailable.
