### PR TITLE
[codex] Enable LTO for Linux and Windows actiond

### DIFF
--- a/cmd/linux-actiond/BUILD.bazel
+++ b/cmd/linux-actiond/BUILD.bazel
@@ -5,10 +5,15 @@ load("//tools:zig_embedded_qemu.bzl", "zig_embedded_qemu")
 
 zig_binary(
     name = "linux-actiond",
+    linkopts = ["-flto"],
     main = "main.zig",
     strip_debug_symbols = True,
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
+    zigopts = [
+        "-flld",
+        "-flto",
+    ],
     deps = [
         ":embedded_assets",
         ":embedded_qemu",

--- a/cmd/windows-actiond/BUILD.bazel
+++ b/cmd/windows-actiond/BUILD.bazel
@@ -5,6 +5,7 @@ load("//tools:zig_embedded_assets.bzl", "zig_embedded_assets")
 zig_binary(
     name = "windows-actiond",
     linkopts = [
+        "-flto",
         "-lcomputecore",
         "-lntdll",
         "-lole32",
@@ -14,6 +15,10 @@ zig_binary(
     strip_debug_symbols = True,
     target_compatible_with = ["@platforms//os:windows"],
     visibility = ["//visibility:public"],
+    zigopts = [
+        "-flld",
+        "-flto",
+    ],
     deps = [
         ":embedded_assets",
         "//src:actiond",


### PR DESCRIPTION
Author: zbarsky-bot

Enable Zig LTO for `linux-actiond` and `windows-actiond`. `zigopts = ["-flld", "-flto"]` keeps Zig IR available to LLD, and `linkopts = ["-flto"]` enables LTO in the final `cc_common.link` action. `darwin-actiond` is unchanged because Zig 0.16 does not support using LLD to link Mach-O files; a final `-flto` alone cannot optimize the native Zig archive.

[GitHub Actions run 27500458810](https://github.com/hermeticbuild/actiond/actions/runs/27500458810) passed all five jobs. The Linux x86_64 LLVM smoke measured 315.286s for actiond and 316.572s for the host, a 0.996x ratio; the `main` comparison measured 269.181s and 273.404s, a 0.985x ratio. The Windows x86_64 LLVM smoke measured 323.007s for actiond and 323.048s for the host, a 1.000x ratio; the `main` comparison measured 352.265s and 366.565s, a 0.961x ratio. Absolute runner times varied, so the actiond/host ratios are the relevant comparison. This single run did not show a performance improvement from LTO.

Global `--copt=-flto` is not included because it also changes the guest Linux kernel and confounds the actiond comparison. actiond's C dependency is zstd, which is used during VM startup rather than action execution.
