### PR TITLE
actiondfs: simplify child parsing, staged mutations, and inode identity

### DIFF
--- a/e2e/LLVM_VM_SMOKE_TIMINGS.md
+++ b/e2e/LLVM_VM_SMOKE_TIMINGS.md
@@ -27,25 +27,25 @@ subset of the VM `llvm-tblgen` graph.
 
 ## Latest Checked-In Result
 
-- Generated: `2026-07-31 18:33:04 EDT`
+- Generated: `2026-07-31 21:55:41 EDT`
 - Command: `ACTIOND_BAZEL_BUILD_FLAGS="--jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" ACTIOND_LLVM_SMOKE_MAC_HOST=0 e2e/run_llvm_vm_smoke.sh`
-- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.2lEP4Y`
+- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.7m9AaQ`
 - Workload: `@llvm-project//llvm:llvm-tblgen`, jobs=8
 - VM warmup target: `//e2e:llvm_exec_warmup`
 - Target and VM host platform: `@llvm//platforms:linux_arm64_musl`
 - Build mode: `-c opt --strip=always --stripopt=--strip-all`
-- VM warmup: `112.244s`; `2207 processes: 190 internal, 2017 remote`
-- Measured VM build: `86.371s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
+- VM warmup: `97.329s`; `2207 processes: 190 internal, 2017 remote`
+- Measured VM build: `147.209s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
 - Measured executions and timing records: `2106`
 - Mac-host baseline: not run (`ACTIOND_LLVM_SMOKE_MAC_HOST=0`)
 
 The previous checked-in run used the same jobs=8 and completed the warmup in
-`137.064s` and measured build in `151.585s`. The current warmup is 18.1% faster
-and the measured build is 43.0% faster with the same 2,106 measured actions.
-The previous run was affected by host CPU and memory contention; its
-unchanged-code repeat took `166.200s` for warmup and `196.180s` for the
-measured build. Compare matched CI actiond/native timings when host contention
-affects local VM measurements.
+`112.244s` and measured build in `86.371s`. The current warmup is 13.3% faster
+with the same 2,017 warmup actions. A concurrent local Drake C++ compilation
+started during the measured build, so its `147.209s` elapsed time is not a
+matched comparison with the previous `86.371s` run. Both measured builds
+executed the same 2,106 actions. Compare matched CI actiond/native timings when
+host CPU or memory contention affects local VM measurements.
 
 Earlier checked-in runs completed the warmup and measured build in
 `102.136s`/`108.831s` and `106.289s`/`138.481s`. A run before action isolation
@@ -59,22 +59,22 @@ Counters include both warmup and measured builds.
 
 | Counter                              | Prior       | Current     |
 | ------------------------------------ | ----------: | ----------: |
-| actiondfs mounts                     |       4,122 |       4,123 |
-| root directory parses                |       1,406 |       1,407 |
-| cached directory hits                |     163,001 |     163,036 |
-| cached directory misses              |       6,616 |       6,629 |
-| directory blob reads                 |       6,615 |       6,628 |
-| staged ensure-directory calls        |      15,996 |      16,001 |
+| actiondfs mounts                     |       4,123 |       4,122 |
+| root directory parses                |       1,407 |       1,406 |
+| cached directory hits                |     163,036 |     163,007 |
+| cached directory misses              |       6,629 |       6,610 |
+| directory blob reads                 |       6,628 |       6,609 |
+| staged ensure-directory calls        |      16,001 |      15,994 |
 | staged ensure-directory components   |          16 |          16 |
 | staged ensure-directory existing     |           0 |           0 |
 | staged ensure-directory created      |          16 |          16 |
-| staged parent dentry hits            |      15,980 |      15,985 |
-| blob-path cache hits                 |     460,692 |     460,969 |
-| blob-path cache misses               |       6,883 |       6,971 |
+| staged parent dentry hits            |      15,985 |      15,978 |
+| blob-path cache hits                 |     460,969 |     460,692 |
+| blob-path cache misses               |       6,971 |       6,883 |
 | blob-path cache evictions            |           0 |           0 |
-| blob-path cache insertion races      |           0 |           1 |
-| staged backing open attempts         |      15,825 |      15,828 |
-| staged backing open lookup           | 0.600 ms    | 0.560 ms    |
+| blob-path cache insertion races      |           1 |           0 |
+| staged backing open attempts         |      15,828 |      15,824 |
+| staged backing open lookup           | 0.560 ms    | 0.648 ms    |
 | staged `copy_file_range` successes   |       3,828 |       3,828 |
 | staged `copy_file_range` fallbacks   |           0 |           0 |
 
@@ -86,12 +86,12 @@ blob-path cache behavior remain close to the previous checked-in result.
 
 All timing values are milliseconds.
 
-| Stage                 |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
-| --------------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| total                 | 7.542 | 21.304 | 28.588 | 58.926 | 1515.831 | 278.694 | 9670.303 |
-| input fetch/setup     | 0.434 |  0.585 |  0.634 |  0.930 |    1.876 |   0.961 |   37.188 |
-| execute               | 6.681 | 19.966 | 26.840 | 56.990 | 1513.261 | 276.576 | 9660.043 |
-| output upload/collect | 0.028 |  0.130 |  0.214 |  1.256 |    4.611 |   1.157 |  120.917 |
+| Stage                 |   Min |    p25 |    p50 |     p75 |      p95 |    Mean |       Max |
+| --------------------- | ----: | -----: | -----: | ------: | -------: | ------: | --------: |
+| total                 | 5.837 | 27.696 | 40.060 | 122.525 | 2616.169 | 477.553 | 17611.456 |
+| input fetch/setup     | 0.418 |  0.592 |  0.683 |   1.104 |    3.948 |   1.700 |   112.102 |
+| execute               | 5.098 | 25.931 | 37.629 | 118.874 | 2613.769 | 474.539 | 17608.027 |
+| output upload/collect | 0.023 |  0.132 |  0.213 |   1.259 |    4.853 |   1.315 |   133.861 |
 
 ## Runner Timing
 
@@ -101,12 +101,12 @@ and lazy actiondfs input reads. All timing values are milliseconds.
 
 | Runner Stage   |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | -------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| parent prepare | 0.053 |  0.100 |  0.126 |  0.155 |    0.379 |   0.181 |   22.556 |
-| fork           | 0.275 |  0.483 |  0.552 |  0.877 |    5.163 |   1.491 |   71.427 |
-| child setup    | 0.005 |  1.672 |  2.836 |  5.095 |   15.060 |   4.965 |  109.687 |
-| process/io     | 0.002 | 15.517 | 21.316 | 41.930 | 1507.324 | 269.409 | 9655.494 |
-| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    3.530 |   0.390 |   19.784 |
-| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.002 |    0.870 |
+| parent prepare | 0.059 |  0.096 |  0.126 |  0.167 |    0.546 |   0.365 |   110.160 |
+| fork           | 0.289 |  0.539 |  0.630 |  1.229 |   11.535 |   3.255 |   264.441 |
+| child setup    | 0.009 |  2.864 |  5.137 |  9.901 |   39.427 |  11.185 |   409.289 |
+| process/io     | 0.812 | 19.219 | 28.286 | 75.714 | 2591.701 | 459.093 | 17592.442 |
+| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    3.337 |   0.350 |    31.314 |
+| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.001 |     0.153 |
 
 ## actiondfs Counters
 
@@ -114,59 +114,59 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 
 | Counter                       |           Value |
 | ----------------------------- | --------------: |
-| mounts                        |           4,123 |
-| root directory parses         |           1,407 |
-| cached directory requests     |         169,665 |
-| cached directory hits         |         163,036 |
-| cached directory misses       |           6,629 |
-| lookups                       |       1,407,099 |
-| lookup hits                   |         842,187 |
-| lookup negative               |         564,912 |
-| blob open attempts            |         474,568 |
-| blob-path cache hits          |         460,969 |
-| blob-path cache misses        |           6,971 |
+| mounts                        |           4,122 |
+| root directory parses         |           1,406 |
+| cached directory requests     |         169,617 |
+| cached directory hits         |         163,007 |
+| cached directory misses       |           6,610 |
+| lookups                       |       1,406,667 |
+| lookup hits                   |         841,778 |
+| lookup negative               |         564,889 |
+| blob open attempts            |         474,184 |
+| blob-path cache hits          |         460,692 |
+| blob-path cache misses        |           6,883 |
 | blob-path cache evictions     |               0 |
-| blob-path cache insertion races |             1 |
-| node blob cache hits          |         472,567 |
-| node blob cache misses        |         467,940 |
-| backing reads                 |         415,500 |
-| backing read bytes            |   1,303,975,362 |
-| mmap calls                    |          53,239 |
-| mmap bytes                    | 1,901,676,589,056 |
+| blob-path cache insertion races |             0 |
+| node blob cache hits          |         472,190 |
+| node blob cache misses        |         467,575 |
+| backing reads                 |         415,332 |
+| backing read bytes            |   1,303,012,282 |
+| mmap calls                    |          53,030 |
+| mmap bytes                    | 1,900,832,624,640 |
 | mmap failures                 |               0 |
-| directory blob reads          |           6,628 |
-| directory blob bytes          |       2,734,781 |
+| directory blob reads          |           6,609 |
+| directory blob bytes          |       2,720,612 |
 
 ## Staged Filesystem Counters
 
 | Counter                              |       Value |
 | ------------------------------------ | ----------: |
-| staged ensure-directory calls        |      16,001 |
+| staged ensure-directory calls        |      15,994 |
 | staged ensure-directory components   |          16 |
 | staged ensure-directory existing     |           0 |
 | staged ensure-directory created      |          16 |
-| staged parent dentry hits            |      15,985 |
-| staged inode lookups                 |   1,407,099 |
-| staged inode unstaged-parent skips   |   1,331,722 |
-| staged inode lookup hits             |      35,524 |
-| staged inode lookup negative         |      39,853 |
-| staged inode input-directory merges  |      18,388 |
-| staged backing open attempts         |      15,828 |
+| staged parent dentry hits            |      15,978 |
+| staged inode lookups                 |   1,406,667 |
+| staged inode unstaged-parent skips   |   1,331,308 |
+| staged inode lookup hits             |      35,518 |
+| staged inode lookup negative         |      39,841 |
+| staged inode input-directory merges  |      18,382 |
+| staged backing open attempts         |      15,824 |
 | staged backing open failures         |           0 |
-| staged backing open total            |   22.149 ms |
-| staged backing open lookup           |    0.560 ms |
-| staged backing open file             |   19.570 ms |
-| staged create calls/successes        |      11,984 |
+| staged backing open total            |   12.551 ms |
+| staged backing open lookup           |    0.648 ms |
+| staged backing open file             |    9.859 ms |
+| staged create calls/successes        |      11,980 |
 | staged mkdir calls/successes         |         198 |
-| staged rename calls/successes        |       3,819 |
-| staged size updates/successes        |       3,876 |
-| staged write calls                   |      37,194 |
-| staged write bytes                   | 106,356,427 |
+| staged rename calls/successes        |       3,816 |
+| staged size updates/successes        |       3,874 |
+| staged write calls                   |      36,943 |
+| staged write bytes                   | 105,212,804 |
 | staged `copy_file_range` successes   |       3,828 |
 | staged `copy_file_range` bytes       |  31,630,764 |
 | staged `copy_file_range` fallbacks   |           0 |
 
-The staged-negative filter skipped 1,331,722 lookups with known-unstaged
+The staged-negative filter skipped 1,331,308 lookups with known-unstaged
 parents. All 3,828 `copy_file_range` attempts succeeded without a buffered
 fallback.
 
@@ -174,14 +174,14 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| CAS put-file calls                   |      7,949 |
-| CAS promotion attempts               |      7,949 |
-| CAS promotion success                |      2,089 |
+| CAS put-file calls                   |      7,946 |
+| CAS promotion attempts               |      7,946 |
+| CAS promotion success                |      2,086 |
 | CAS existing-blob hits               |      5,860 |
-| CAS promoted bytes                   | 37,922,351 |
-| CAS digest bytes                     | 90,256,303 |
-| CAS promotion digest                 | 710.295 ms |
-| CAS promotion rename                 | 227.487 ms |
+| CAS promoted bytes                   | 31,268,199 |
+| CAS digest bytes                     | 83,602,151 |
+| CAS promotion digest                 | 792.857 ms |
+| CAS promotion rename                 | 147.752 ms |
 | CAS cross-device fallbacks           |          0 |
 | CAS permission fallbacks             |          0 |
 | CAS put-file copy calls              |          0 |
@@ -190,19 +190,19 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| ByteStream file reads                |      4,045 |
-| ByteStream file bytes                | 63,436,296 |
+| ByteStream file reads                |      4,037 |
+| ByteStream file bytes                | 57,511,165 |
 | ByteStream buffered reads            |          0 |
-| gRPC response tasks started          |     36,255 |
+| gRPC response tasks started          |     36,228 |
 | gRPC response tasks failed           |          0 |
 | gRPC response concurrency waits      |          0 |
-| gRPC data frames                     |     37,397 |
-| gRPC file payload frames             |      7,263 |
-| gRPC `sendfile` attempts/successes   |      7,263 |
-| gRPC `sendfile` bytes                | 63,436,296 |
+| gRPC data frames                     |     37,003 |
+| gRPC file payload frames             |      6,895 |
+| gRPC `sendfile` attempts/successes   |      6,895 |
+| gRPC `sendfile` bytes                | 57,511,165 |
 | gRPC `sendfile` fallbacks            |          0 |
 
-The measured TCP-to-vsock bridge logged two connections, 27.62 MiB from client
+The measured TCP-to-vsock bridge logged two connections, 28.23 MiB from client
 to guest, 37.37 MiB from guest to client, and zero read/write pump errors.
-ByteStream reads remained file-backed and all 7,263 gRPC `sendfile` attempts
+ByteStream reads remained file-backed and all 6,895 gRPC `sendfile` attempts
 succeeded.

--- a/e2e/LLVM_VM_SMOKE_TIMINGS.md
+++ b/e2e/LLVM_VM_SMOKE_TIMINGS.md
@@ -27,24 +27,32 @@ subset of the VM `llvm-tblgen` graph.
 
 ## Latest Checked-In Result
 
-- Generated: `2026-07-31 14:08:55 EDT`
+- Generated: `2026-07-31 15:21:16 EDT`
 - Command: `ACTIOND_BAZEL_BUILD_FLAGS="--jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" ACTIOND_LLVM_SMOKE_MAC_HOST=0 e2e/run_llvm_vm_smoke.sh`
-- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.DAQ5ki`
+- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.r89W0G`
 - Workload: `@llvm-project//llvm:llvm-tblgen`, jobs=8
 - VM warmup target: `//e2e:llvm_exec_warmup`
 - Target and VM host platform: `@llvm//platforms:linux_arm64_musl`
 - Build mode: `-c opt --strip=always --stripopt=--strip-all`
-- VM warmup: `102.136s`; `2207 processes: 190 internal, 2017 remote`
-- Measured VM build: `108.831s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
+- VM warmup: `137.064s`; `2207 processes: 190 internal, 2017 remote`
+- Measured VM build: `151.585s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
 - Measured executions and timing records: `2106`
 - Mac-host baseline: not run (`ACTIOND_LLVM_SMOKE_MAC_HOST=0`)
 
 The previous checked-in run used the same jobs=8 and completed the warmup in
-`106.289s` and measured build in `138.481s`. The current warmup is 3.9% faster,
-and the measured build is 21.4% faster with the same 2,106 measured actions.
-An earlier run before action isolation completed the warmup in `88.364s` and
-the measured build in `91.490s`. An intermediate action-isolation run took
-`256.834s` for warmup and `140.328s` for the measured build.
+`102.136s` and measured build in `108.831s`. The current warmup is 34.2% slower
+and the measured build is 39.3% slower with the same 2,106 measured actions.
+An immediate unchanged-code repeat took `166.200s` for warmup and `196.180s`
+for the measured build while unrelated local C++ compilers and other processes
+were active. Compared with the previous run, 91.9% of the summed action-time
+increase was action `process/io`, while actiondfs reads, opens, lookups, and
+errors were unchanged. Compare matched CI actiond/native timings when host CPU
+and memory contention affect local VM measurements.
+
+An earlier checked-in run completed the warmup in `106.289s` and the measured
+build in `138.481s`. A run before action isolation completed the warmup in
+`88.364s` and the measured build in `91.490s`. An intermediate action-isolation
+run took `256.834s` for warmup and `140.328s` for the measured build.
 
 ## Filesystem Comparison With Prior Checked-In Run
 
@@ -52,24 +60,24 @@ Counters include both warmup and measured builds.
 
 | Counter                              | Prior       | Current     |
 | ------------------------------------ | ----------: | ----------: |
-| actiondfs mounts                     |       4,108 |       4,123 |
-| root directory parses                |       1,403 |       1,407 |
-| cached directory hits                |     162,614 |     163,045 |
-| cached directory misses              |       6,603 |       6,620 |
-| directory blob reads                 |       6,602 |       6,619 |
-| staged ensure-directory calls        |      15,949 |      16,001 |
-| staged ensure-directory components   |          15 |          16 |
+| actiondfs mounts                     |       4,123 |       4,122 |
+| root directory parses                |       1,407 |       1,406 |
+| cached directory hits                |     163,045 |     163,001 |
+| cached directory misses              |       6,620 |       6,616 |
+| directory blob reads                 |       6,619 |       6,615 |
+| staged ensure-directory calls        |      16,001 |      15,996 |
+| staged ensure-directory components   |          16 |          16 |
 | staged ensure-directory existing     |           0 |           0 |
-| staged ensure-directory created      |          15 |          16 |
-| staged parent dentry hits            |      15,934 |      15,985 |
-| blob-path cache hits                 |     459,163 |     460,970 |
-| blob-path cache misses               |       6,881 |       6,970 |
+| staged ensure-directory created      |          16 |          16 |
+| staged parent dentry hits            |      15,985 |      15,980 |
+| blob-path cache hits                 |     460,970 |     460,692 |
+| blob-path cache misses               |       6,970 |       6,883 |
 | blob-path cache evictions            |           0 |           0 |
 | blob-path cache insertion races      |           0 |           0 |
-| staged backing open attempts         |      15,782 |      15,828 |
-| staged backing open lookup           | 0.866 ms    | 0.961 ms    |
-| staged `copy_file_range` successes   |       3,819 |       3,828 |
-| staged `copy_file_range` fallbacks   |           1 |           0 |
+| staged backing open attempts         |      15,828 |      15,825 |
+| staged backing open lookup           | 0.961 ms    | 0.600 ms    |
+| staged `copy_file_range` successes   |       3,828 |       3,828 |
+| staged `copy_file_range` fallbacks   |           0 |           0 |
 
 The workload retained the same 2,017 warmup actions and 2,106 measured actions.
 Root-directory parsing, directory blob reads, staged parent-directory reuse, and
@@ -81,10 +89,10 @@ All timing values are milliseconds.
 
 | Stage                 |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | --------------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| total                 | 7.336 | 24.941 | 34.556 |  81.765 | 2004.324 | 368.775 | 20643.456 |
-| input fetch/setup     | 0.430 |  0.597 |  0.731 |   1.120 |    2.889 |   1.397 |   103.123 |
-| execute               | 6.722 | 23.152 | 32.609 |  78.352 | 1999.729 | 365.805 | 20636.110 |
-| output upload/collect | 0.032 |  0.137 |  0.253 |   1.483 |    5.958 |   1.573 |   314.718 |
+| total                 | 10.467 | 30.075 | 47.931 | 177.485 | 2691.978 | 503.038 | 17790.613 |
+| input fetch/setup     |  0.428 |  0.599 |  0.706 |   1.178 |    5.151 |   2.216 |   148.489 |
+| execute               |  8.838 | 28.178 | 45.168 | 166.368 | 2688.531 | 499.166 | 17782.837 |
+| output upload/collect |  0.022 |  0.145 |  0.287 |   1.664 |    5.737 |   1.655 |   175.722 |
 
 ## Runner Timing
 
@@ -94,12 +102,12 @@ and lazy actiondfs input reads. All timing values are milliseconds.
 
 | Runner Stage   |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | -------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| parent prepare | 0.059 |  0.102 |  0.129 |   0.173 |    0.545 |   0.253 |    35.359 |
-| fork           | 0.319 |  0.533 |  0.622 |   1.065 |    5.682 |   1.817 |   109.051 |
-| child setup    | 0.008 |  2.191 |  3.728 |   7.078 |   27.496 |   7.697 |   215.098 |
-| process/io     | 1.622 | 17.841 | 25.036 |  59.728 | 1981.904 | 355.418 | 20631.081 |
-| wait           | 0.000 |  0.000 |  0.000 |   0.000 |    2.669 |   0.286 |    33.530 |
-| stdio digest   | 0.000 |  0.000 |  0.001 |   0.001 |    0.001 |   0.001 |     0.141 |
+| parent prepare | 0.058 |  0.105 |  0.130 |   0.183 |    0.760 |   0.713 |   125.178 |
+| fork           | 0.560 |  0.904 |  1.086 |   2.362 |   16.226 |   4.886 |   305.062 |
+| child setup    | 0.009 |  3.571 |  5.878 |  11.076 |   49.143 |  13.804 |   463.233 |
+| process/io     | 2.352 | 19.521 | 31.235 | 103.996 | 2680.702 | 478.850 | 17776.924 |
+| wait           | 0.000 |  0.000 |  0.000 |   0.000 |    4.251 |   0.582 |   123.580 |
+| stdio digest   | 0.000 |  0.001 |  0.001 |   0.001 |    0.001 |   0.001 |     0.245 |
 
 ## actiondfs Counters
 
@@ -107,59 +115,59 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 
 | Counter                       |           Value |
 | ----------------------------- | --------------: |
-| mounts                        |           4,123 |
-| root directory parses         |           1,407 |
-| cached directory requests     |         169,665 |
-| cached directory hits         |         163,045 |
-| cached directory misses       |           6,620 |
-| lookups                       |       1,407,099 |
-| lookup hits                   |         842,187 |
-| lookup negative               |         564,912 |
-| blob open attempts            |         474,559 |
-| blob-path cache hits          |         460,970 |
-| blob-path cache misses        |           6,970 |
+| mounts                        |           4,122 |
+| root directory parses         |           1,406 |
+| cached directory requests     |         169,617 |
+| cached directory hits         |         163,001 |
+| cached directory misses       |           6,616 |
+| lookups                       |       1,406,668 |
+| lookup hits                   |         841,778 |
+| lookup negative               |         564,890 |
+| blob open attempts            |         474,190 |
+| blob-path cache hits          |         460,692 |
+| blob-path cache misses        |           6,883 |
 | blob-path cache evictions     |               0 |
 | blob-path cache insertion races |             0 |
-| node blob cache hits          |         472,567 |
-| node blob cache misses        |         467,940 |
-| backing reads                 |         415,500 |
-| backing read bytes            |   1,303,975,362 |
-| mmap calls                    |          53,239 |
-| mmap bytes                    | 1,901,676,589,056 |
+| node blob cache hits          |         472,190 |
+| node blob cache misses        |         467,575 |
+| backing reads                 |         415,332 |
+| backing read bytes            |   1,303,012,282 |
+| mmap calls                    |          53,030 |
+| mmap bytes                    | 1,900,832,624,640 |
 | mmap failures                 |               0 |
-| directory blob reads          |           6,619 |
-| directory blob bytes          |       2,731,829 |
+| directory blob reads          |           6,615 |
+| directory blob bytes          |       2,729,935 |
 
 ## Staged Filesystem Counters
 
 | Counter                              |       Value |
 | ------------------------------------ | ----------: |
-| staged ensure-directory calls        |      16,001 |
+| staged ensure-directory calls        |      15,996 |
 | staged ensure-directory components   |          16 |
 | staged ensure-directory existing     |           0 |
 | staged ensure-directory created      |          16 |
-| staged parent dentry hits            |      15,985 |
-| staged inode lookups                 |   1,407,099 |
-| staged inode unstaged-parent skips   |   1,331,723 |
-| staged inode lookup hits             |      35,524 |
-| staged inode lookup negative         |      39,852 |
-| staged inode input-directory merges  |      18,388 |
-| staged backing open attempts         |      15,828 |
+| staged parent dentry hits            |      15,980 |
+| staged inode lookups                 |   1,406,668 |
+| staged inode unstaged-parent skips   |   1,331,309 |
+| staged inode lookup hits             |      35,518 |
+| staged inode lookup negative         |      39,841 |
+| staged inode input-directory merges  |      18,382 |
+| staged backing open attempts         |      15,825 |
 | staged backing open failures         |           0 |
-| staged backing open total            |   14.863 ms |
-| staged backing open lookup           |    0.961 ms |
-| staged backing open file             |   11.764 ms |
-| staged create calls/successes        |      11,984 |
+| staged backing open total            |   15.511 ms |
+| staged backing open lookup           |    0.600 ms |
+| staged backing open file             |   12.684 ms |
+| staged create calls/successes        |      11,981 |
 | staged mkdir calls/successes         |         198 |
-| staged rename calls/successes        |       3,819 |
-| staged size updates/successes        |       3,876 |
-| staged write calls                   |      37,194 |
-| staged write bytes                   | 106,356,427 |
+| staged rename calls/successes        |       3,817 |
+| staged size updates/successes        |       3,874 |
+| staged write calls                   |      37,140 |
+| staged write bytes                   | 106,132,435 |
 | staged `copy_file_range` successes   |       3,828 |
 | staged `copy_file_range` bytes       |  31,630,764 |
 | staged `copy_file_range` fallbacks   |           0 |
 
-The staged-negative filter skipped 1,331,723 lookups with known-unstaged
+The staged-negative filter skipped 1,331,309 lookups with known-unstaged
 parents. All 3,828 `copy_file_range` attempts succeeded without a buffered
 fallback.
 
@@ -167,14 +175,14 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| CAS put-file calls                   |      7,949 |
-| CAS promotion attempts               |      7,949 |
-| CAS promotion success                |      2,089 |
+| CAS put-file calls                   |      7,947 |
+| CAS promotion attempts               |      7,947 |
+| CAS promotion success                |      2,087 |
 | CAS existing-blob hits               |      5,860 |
-| CAS promoted bytes                   | 37,922,351 |
-| CAS digest bytes                     | 90,256,303 |
-| CAS promotion digest                 | 961.559 ms |
-| CAS promotion rename                 | 145.351 ms |
+| CAS promoted bytes                   | 32,082,447 |
+| CAS digest bytes                     | 84,416,399 |
+| CAS promotion digest                 | 863.028 ms |
+| CAS promotion rename                 | 211.363 ms |
 | CAS cross-device fallbacks           |          0 |
 | CAS permission fallbacks             |          0 |
 | CAS put-file copy calls              |          0 |
@@ -183,19 +191,19 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| ByteStream file reads                |      4,045 |
-| ByteStream file bytes                | 63,436,296 |
+| ByteStream file reads                |      4,038 |
+| ByteStream file bytes                | 57,616,538 |
 | ByteStream buffered reads            |          0 |
-| gRPC response tasks started          |     36,255 |
+| gRPC response tasks started          |     36,229 |
 | gRPC response tasks failed           |          0 |
 | gRPC response concurrency waits      |          0 |
-| gRPC data frames                     |     37,396 |
-| gRPC file payload frames             |      7,263 |
-| gRPC `sendfile` attempts/successes   |      7,263 |
-| gRPC `sendfile` bytes                | 63,436,296 |
+| gRPC data frames                     |     37,010 |
+| gRPC file payload frames             |      6,902 |
+| gRPC `sendfile` attempts/successes   |      6,902 |
+| gRPC `sendfile` bytes                | 57,616,538 |
 | gRPC `sendfile` fallbacks            |          0 |
 
-The measured TCP-to-vsock bridge logged two connections, 28.03 MiB from client
-to guest, 37.37 MiB from guest to client, and zero read/write pump errors.
-ByteStream reads remained file-backed and all 7,263 gRPC `sendfile` attempts
+The measured TCP-to-vsock bridge logged two connections, 28.30 MiB from client
+to guest, 37.38 MiB from guest to client, and zero read/write pump errors.
+ByteStream reads remained file-backed and all 6,902 gRPC `sendfile` attempts
 succeeded.

--- a/e2e/LLVM_VM_SMOKE_TIMINGS.md
+++ b/e2e/LLVM_VM_SMOKE_TIMINGS.md
@@ -27,32 +27,31 @@ subset of the VM `llvm-tblgen` graph.
 
 ## Latest Checked-In Result
 
-- Generated: `2026-07-31 15:21:16 EDT`
+- Generated: `2026-07-31 18:33:04 EDT`
 - Command: `ACTIOND_BAZEL_BUILD_FLAGS="--jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" ACTIOND_LLVM_SMOKE_MAC_HOST=0 e2e/run_llvm_vm_smoke.sh`
-- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.r89W0G`
+- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.2lEP4Y`
 - Workload: `@llvm-project//llvm:llvm-tblgen`, jobs=8
 - VM warmup target: `//e2e:llvm_exec_warmup`
 - Target and VM host platform: `@llvm//platforms:linux_arm64_musl`
 - Build mode: `-c opt --strip=always --stripopt=--strip-all`
-- VM warmup: `137.064s`; `2207 processes: 190 internal, 2017 remote`
-- Measured VM build: `151.585s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
+- VM warmup: `112.244s`; `2207 processes: 190 internal, 2017 remote`
+- Measured VM build: `86.371s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
 - Measured executions and timing records: `2106`
 - Mac-host baseline: not run (`ACTIOND_LLVM_SMOKE_MAC_HOST=0`)
 
 The previous checked-in run used the same jobs=8 and completed the warmup in
-`102.136s` and measured build in `108.831s`. The current warmup is 34.2% slower
-and the measured build is 39.3% slower with the same 2,106 measured actions.
-An immediate unchanged-code repeat took `166.200s` for warmup and `196.180s`
-for the measured build while unrelated local C++ compilers and other processes
-were active. Compared with the previous run, 91.9% of the summed action-time
-increase was action `process/io`, while actiondfs reads, opens, lookups, and
-errors were unchanged. Compare matched CI actiond/native timings when host CPU
-and memory contention affect local VM measurements.
+`137.064s` and measured build in `151.585s`. The current warmup is 18.1% faster
+and the measured build is 43.0% faster with the same 2,106 measured actions.
+The previous run was affected by host CPU and memory contention; its
+unchanged-code repeat took `166.200s` for warmup and `196.180s` for the
+measured build. Compare matched CI actiond/native timings when host contention
+affects local VM measurements.
 
-An earlier checked-in run completed the warmup in `106.289s` and the measured
-build in `138.481s`. A run before action isolation completed the warmup in
-`88.364s` and the measured build in `91.490s`. An intermediate action-isolation
-run took `256.834s` for warmup and `140.328s` for the measured build.
+Earlier checked-in runs completed the warmup and measured build in
+`102.136s`/`108.831s` and `106.289s`/`138.481s`. A run before action isolation
+completed the warmup in `88.364s` and the measured build in `91.490s`. An
+intermediate action-isolation run took `256.834s` for warmup and `140.328s`
+for the measured build.
 
 ## Filesystem Comparison With Prior Checked-In Run
 
@@ -60,22 +59,22 @@ Counters include both warmup and measured builds.
 
 | Counter                              | Prior       | Current     |
 | ------------------------------------ | ----------: | ----------: |
-| actiondfs mounts                     |       4,123 |       4,122 |
-| root directory parses                |       1,407 |       1,406 |
-| cached directory hits                |     163,045 |     163,001 |
-| cached directory misses              |       6,620 |       6,616 |
-| directory blob reads                 |       6,619 |       6,615 |
-| staged ensure-directory calls        |      16,001 |      15,996 |
+| actiondfs mounts                     |       4,122 |       4,123 |
+| root directory parses                |       1,406 |       1,407 |
+| cached directory hits                |     163,001 |     163,036 |
+| cached directory misses              |       6,616 |       6,629 |
+| directory blob reads                 |       6,615 |       6,628 |
+| staged ensure-directory calls        |      15,996 |      16,001 |
 | staged ensure-directory components   |          16 |          16 |
 | staged ensure-directory existing     |           0 |           0 |
 | staged ensure-directory created      |          16 |          16 |
-| staged parent dentry hits            |      15,985 |      15,980 |
-| blob-path cache hits                 |     460,970 |     460,692 |
-| blob-path cache misses               |       6,970 |       6,883 |
+| staged parent dentry hits            |      15,980 |      15,985 |
+| blob-path cache hits                 |     460,692 |     460,969 |
+| blob-path cache misses               |       6,883 |       6,971 |
 | blob-path cache evictions            |           0 |           0 |
-| blob-path cache insertion races      |           0 |           0 |
-| staged backing open attempts         |      15,828 |      15,825 |
-| staged backing open lookup           | 0.961 ms    | 0.600 ms    |
+| blob-path cache insertion races      |           0 |           1 |
+| staged backing open attempts         |      15,825 |      15,828 |
+| staged backing open lookup           | 0.600 ms    | 0.560 ms    |
 | staged `copy_file_range` successes   |       3,828 |       3,828 |
 | staged `copy_file_range` fallbacks   |           0 |           0 |
 
@@ -89,10 +88,10 @@ All timing values are milliseconds.
 
 | Stage                 |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | --------------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| total                 | 10.467 | 30.075 | 47.931 | 177.485 | 2691.978 | 503.038 | 17790.613 |
-| input fetch/setup     |  0.428 |  0.599 |  0.706 |   1.178 |    5.151 |   2.216 |   148.489 |
-| execute               |  8.838 | 28.178 | 45.168 | 166.368 | 2688.531 | 499.166 | 17782.837 |
-| output upload/collect |  0.022 |  0.145 |  0.287 |   1.664 |    5.737 |   1.655 |   175.722 |
+| total                 | 7.542 | 21.304 | 28.588 | 58.926 | 1515.831 | 278.694 | 9670.303 |
+| input fetch/setup     | 0.434 |  0.585 |  0.634 |  0.930 |    1.876 |   0.961 |   37.188 |
+| execute               | 6.681 | 19.966 | 26.840 | 56.990 | 1513.261 | 276.576 | 9660.043 |
+| output upload/collect | 0.028 |  0.130 |  0.214 |  1.256 |    4.611 |   1.157 |  120.917 |
 
 ## Runner Timing
 
@@ -102,12 +101,12 @@ and lazy actiondfs input reads. All timing values are milliseconds.
 
 | Runner Stage   |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | -------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| parent prepare | 0.058 |  0.105 |  0.130 |   0.183 |    0.760 |   0.713 |   125.178 |
-| fork           | 0.560 |  0.904 |  1.086 |   2.362 |   16.226 |   4.886 |   305.062 |
-| child setup    | 0.009 |  3.571 |  5.878 |  11.076 |   49.143 |  13.804 |   463.233 |
-| process/io     | 2.352 | 19.521 | 31.235 | 103.996 | 2680.702 | 478.850 | 17776.924 |
-| wait           | 0.000 |  0.000 |  0.000 |   0.000 |    4.251 |   0.582 |   123.580 |
-| stdio digest   | 0.000 |  0.001 |  0.001 |   0.001 |    0.001 |   0.001 |     0.245 |
+| parent prepare | 0.053 |  0.100 |  0.126 |  0.155 |    0.379 |   0.181 |   22.556 |
+| fork           | 0.275 |  0.483 |  0.552 |  0.877 |    5.163 |   1.491 |   71.427 |
+| child setup    | 0.005 |  1.672 |  2.836 |  5.095 |   15.060 |   4.965 |  109.687 |
+| process/io     | 0.002 | 15.517 | 21.316 | 41.930 | 1507.324 | 269.409 | 9655.494 |
+| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    3.530 |   0.390 |   19.784 |
+| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.002 |    0.870 |
 
 ## actiondfs Counters
 
@@ -115,59 +114,59 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 
 | Counter                       |           Value |
 | ----------------------------- | --------------: |
-| mounts                        |           4,122 |
-| root directory parses         |           1,406 |
-| cached directory requests     |         169,617 |
-| cached directory hits         |         163,001 |
-| cached directory misses       |           6,616 |
-| lookups                       |       1,406,668 |
-| lookup hits                   |         841,778 |
-| lookup negative               |         564,890 |
-| blob open attempts            |         474,190 |
-| blob-path cache hits          |         460,692 |
-| blob-path cache misses        |           6,883 |
+| mounts                        |           4,123 |
+| root directory parses         |           1,407 |
+| cached directory requests     |         169,665 |
+| cached directory hits         |         163,036 |
+| cached directory misses       |           6,629 |
+| lookups                       |       1,407,099 |
+| lookup hits                   |         842,187 |
+| lookup negative               |         564,912 |
+| blob open attempts            |         474,568 |
+| blob-path cache hits          |         460,969 |
+| blob-path cache misses        |           6,971 |
 | blob-path cache evictions     |               0 |
-| blob-path cache insertion races |             0 |
-| node blob cache hits          |         472,190 |
-| node blob cache misses        |         467,575 |
-| backing reads                 |         415,332 |
-| backing read bytes            |   1,303,012,282 |
-| mmap calls                    |          53,030 |
-| mmap bytes                    | 1,900,832,624,640 |
+| blob-path cache insertion races |             1 |
+| node blob cache hits          |         472,567 |
+| node blob cache misses        |         467,940 |
+| backing reads                 |         415,500 |
+| backing read bytes            |   1,303,975,362 |
+| mmap calls                    |          53,239 |
+| mmap bytes                    | 1,901,676,589,056 |
 | mmap failures                 |               0 |
-| directory blob reads          |           6,615 |
-| directory blob bytes          |       2,729,935 |
+| directory blob reads          |           6,628 |
+| directory blob bytes          |       2,734,781 |
 
 ## Staged Filesystem Counters
 
 | Counter                              |       Value |
 | ------------------------------------ | ----------: |
-| staged ensure-directory calls        |      15,996 |
+| staged ensure-directory calls        |      16,001 |
 | staged ensure-directory components   |          16 |
 | staged ensure-directory existing     |           0 |
 | staged ensure-directory created      |          16 |
-| staged parent dentry hits            |      15,980 |
-| staged inode lookups                 |   1,406,668 |
-| staged inode unstaged-parent skips   |   1,331,309 |
-| staged inode lookup hits             |      35,518 |
-| staged inode lookup negative         |      39,841 |
-| staged inode input-directory merges  |      18,382 |
-| staged backing open attempts         |      15,825 |
+| staged parent dentry hits            |      15,985 |
+| staged inode lookups                 |   1,407,099 |
+| staged inode unstaged-parent skips   |   1,331,722 |
+| staged inode lookup hits             |      35,524 |
+| staged inode lookup negative         |      39,853 |
+| staged inode input-directory merges  |      18,388 |
+| staged backing open attempts         |      15,828 |
 | staged backing open failures         |           0 |
-| staged backing open total            |   15.511 ms |
-| staged backing open lookup           |    0.600 ms |
-| staged backing open file             |   12.684 ms |
-| staged create calls/successes        |      11,981 |
+| staged backing open total            |   22.149 ms |
+| staged backing open lookup           |    0.560 ms |
+| staged backing open file             |   19.570 ms |
+| staged create calls/successes        |      11,984 |
 | staged mkdir calls/successes         |         198 |
-| staged rename calls/successes        |       3,817 |
-| staged size updates/successes        |       3,874 |
-| staged write calls                   |      37,140 |
-| staged write bytes                   | 106,132,435 |
+| staged rename calls/successes        |       3,819 |
+| staged size updates/successes        |       3,876 |
+| staged write calls                   |      37,194 |
+| staged write bytes                   | 106,356,427 |
 | staged `copy_file_range` successes   |       3,828 |
 | staged `copy_file_range` bytes       |  31,630,764 |
 | staged `copy_file_range` fallbacks   |           0 |
 
-The staged-negative filter skipped 1,331,309 lookups with known-unstaged
+The staged-negative filter skipped 1,331,722 lookups with known-unstaged
 parents. All 3,828 `copy_file_range` attempts succeeded without a buffered
 fallback.
 
@@ -175,14 +174,14 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| CAS put-file calls                   |      7,947 |
-| CAS promotion attempts               |      7,947 |
-| CAS promotion success                |      2,087 |
+| CAS put-file calls                   |      7,949 |
+| CAS promotion attempts               |      7,949 |
+| CAS promotion success                |      2,089 |
 | CAS existing-blob hits               |      5,860 |
-| CAS promoted bytes                   | 32,082,447 |
-| CAS digest bytes                     | 84,416,399 |
-| CAS promotion digest                 | 863.028 ms |
-| CAS promotion rename                 | 211.363 ms |
+| CAS promoted bytes                   | 37,922,351 |
+| CAS digest bytes                     | 90,256,303 |
+| CAS promotion digest                 | 710.295 ms |
+| CAS promotion rename                 | 227.487 ms |
 | CAS cross-device fallbacks           |          0 |
 | CAS permission fallbacks             |          0 |
 | CAS put-file copy calls              |          0 |
@@ -191,19 +190,19 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| ByteStream file reads                |      4,038 |
-| ByteStream file bytes                | 57,616,538 |
+| ByteStream file reads                |      4,045 |
+| ByteStream file bytes                | 63,436,296 |
 | ByteStream buffered reads            |          0 |
-| gRPC response tasks started          |     36,229 |
+| gRPC response tasks started          |     36,255 |
 | gRPC response tasks failed           |          0 |
 | gRPC response concurrency waits      |          0 |
-| gRPC data frames                     |     37,010 |
-| gRPC file payload frames             |      6,902 |
-| gRPC `sendfile` attempts/successes   |      6,902 |
-| gRPC `sendfile` bytes                | 57,616,538 |
+| gRPC data frames                     |     37,397 |
+| gRPC file payload frames             |      7,263 |
+| gRPC `sendfile` attempts/successes   |      7,263 |
+| gRPC `sendfile` bytes                | 63,436,296 |
 | gRPC `sendfile` fallbacks            |          0 |
 
-The measured TCP-to-vsock bridge logged two connections, 28.30 MiB from client
-to guest, 37.38 MiB from guest to client, and zero read/write pump errors.
-ByteStream reads remained file-backed and all 6,902 gRPC `sendfile` attempts
+The measured TCP-to-vsock bridge logged two connections, 27.62 MiB from client
+to guest, 37.37 MiB from guest to client, and zero read/write pump errors.
+ByteStream reads remained file-backed and all 7,263 gRPC `sendfile` attempts
 succeeded.

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2592,9 +2592,9 @@ static struct dentry *actiondfs_lookup(struct inode *dir,
 	return NULL;
 }
 
-static int actiondfs_create_staged_file(struct inode *dir,
-					struct dentry *dentry, umode_t mode,
-					const char *target, bool excl)
+static int actiondfs_create_staged_child(struct inode *dir,
+					 struct dentry *dentry, umode_t mode,
+					 const char *target, bool excl)
 {
 	struct actiondfs_node *parent = dir->i_private;
 	struct actiondfs_sb_info *sbi = actiondfs_sbi(dir->i_sb);
@@ -2636,20 +2636,38 @@ static int actiondfs_create_staged_file(struct inode *dir,
 		actiondfs_stage_unlock_child(&parent_path, real_dentry);
 		goto out_drop_write;
 	}
-	if (target)
+	if (S_ISDIR(mode)) {
+		struct dentry *created;
+
+		created = vfs_mkdir(mnt_idmap(parent_path.mnt),
+				    d_inode(parent_path.dentry), real_dentry,
+				    mode & S_IALLUGO);
+		inode_unlock(d_inode(parent_path.dentry));
+		if (IS_ERR(created)) {
+			err = PTR_ERR(created);
+			goto out_drop_write;
+		}
+		real_dentry = created;
+		err = 0;
+	} else if (target) {
 		err = vfs_symlink(mnt_idmap(parent_path.mnt),
 				  d_inode(parent_path.dentry), real_dentry,
 				  target);
-	else
+		inode_unlock(d_inode(parent_path.dentry));
+	} else {
 		err = vfs_create(mnt_idmap(parent_path.mnt),
 				 d_inode(parent_path.dentry), real_dentry,
 				 mode & 0777, excl);
-	inode_unlock(d_inode(parent_path.dentry));
-	if (!err)
-		actiondfs_insert_staged_inode(inode, real_dentry);
-	dput(real_dentry);
-	if (err)
+		inode_unlock(d_inode(parent_path.dentry));
+	}
+	if (err) {
+		dput(real_dentry);
 		goto out_drop_write;
+	}
+	actiondfs_insert_staged_inode(inode, real_dentry);
+	dput(real_dentry);
+	if (S_ISDIR(mode))
+		inc_nlink(dir);
 	d_instantiate(dentry, inode);
 	inode = NULL;
 	actiondfs_note_stage_change(parent);
@@ -2671,8 +2689,8 @@ static int actiondfs_create(struct mnt_idmap *idmap, struct inode *dir,
 	if (!actiondfs_sbi(dir->i_sb)->stage_path.dentry)
 		return -EROFS;
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CREATE_CALLS);
-	err = actiondfs_create_staged_file(dir, dentry,
-					  S_IFREG | (mode & 0777), NULL, excl);
+	err = actiondfs_create_staged_child(dir, dentry,
+					   S_IFREG | (mode & 0777), NULL, excl);
 	actiondfs_stat_inc(err ? ACTIONDFS_STAT_STAGE_CREATE_FAILURES :
 			  ACTIONDFS_STAT_STAGE_CREATE_SUCCESS);
 	return err;
@@ -2683,82 +2701,24 @@ static int actiondfs_symlink(struct mnt_idmap *idmap, struct inode *dir,
 {
 	if (!actiondfs_sbi(dir->i_sb)->stage_path.dentry)
 		return -EROFS;
-	return actiondfs_create_staged_file(dir, dentry, S_IFLNK | 0777,
-					    target, false);
+	return actiondfs_create_staged_child(dir, dentry, S_IFLNK | 0777,
+					     target, false);
 }
 
 static struct dentry *actiondfs_mkdir(struct mnt_idmap *idmap,
 				      struct inode *dir,
 				      struct dentry *dentry, umode_t mode)
 {
-	struct actiondfs_node *parent = dir->i_private;
-	struct actiondfs_sb_info *sbi = actiondfs_sbi(dir->i_sb);
-	struct inode *inode;
-	struct path parent_path;
-	struct dentry *real_dentry;
-	struct dentry *created;
 	int err;
 
-	if (!sbi->stage_path.dentry)
+	if (!actiondfs_sbi(dir->i_sb)->stage_path.dentry)
 		return ERR_PTR(-EROFS);
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_MKDIR_CALLS);
-	err = actiondfs_ensure_loaded(dir->i_sb, parent);
-	if (err) {
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_MKDIR_FAILURES);
-		return ERR_PTR(err);
-	}
-	if (actiondfs_find_cached_child(parent, dentry->d_name.name,
-						dentry->d_name.len)) {
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_MKDIR_FAILURES);
-		return ERR_PTR(-EROFS);
-	}
-	inode = actiondfs_prealloc_staged_inode(dir->i_sb, parent,
-					       S_IFDIR | (mode & S_IALLUGO), NULL, 0);
-	if (IS_ERR(inode)) {
-		err = PTR_ERR(inode);
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_MKDIR_FAILURES);
-		return ERR_PTR(err);
-	}
-
-	err = actiondfs_ensure_stage_parent_path(sbi, parent, &parent_path);
-	if (err)
-		goto out_put_inode;
-	err = mnt_want_write(parent_path.mnt);
-	if (err)
-		goto out_put_path;
-	err = actiondfs_stage_lookup_child(&parent_path, dentry->d_name.name,
-					   dentry->d_name.len, &real_dentry);
-	if (err)
-		goto out_drop_write;
-	created = vfs_mkdir(mnt_idmap(parent_path.mnt),
-			    d_inode(parent_path.dentry), real_dentry,
-			    mode & S_IALLUGO);
-	inode_unlock(d_inode(parent_path.dentry));
-	if (IS_ERR(created)) {
-		err = PTR_ERR(created);
-	} else {
-		err = 0;
-	}
-	if (err)
-		goto out_drop_write;
-	actiondfs_insert_staged_inode(inode, created);
-	dput(created);
-	inc_nlink(dir);
-	d_instantiate(dentry, inode);
-	inode = NULL;
-	actiondfs_note_stage_change(parent);
-
-out_drop_write:
-	mnt_drop_write(parent_path.mnt);
-out_put_path:
-	path_put(&parent_path);
-out_put_inode:
-	if (inode)
-		iput(inode);
-	if (err)
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_MKDIR_FAILURES);
-	else
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_MKDIR_SUCCESS);
+	err = actiondfs_create_staged_child(dir, dentry,
+					   S_IFDIR | (mode & S_IALLUGO),
+					   NULL, false);
+	actiondfs_stat_inc(err ? ACTIONDFS_STAT_STAGE_MKDIR_FAILURES :
+			  ACTIONDFS_STAT_STAGE_MKDIR_SUCCESS);
 	return ERR_PTR(err);
 }
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -438,10 +438,8 @@ static struct actiondfs_node *actiondfs_alloc_node(umode_t mode)
 	if (!node)
 		return NULL;
 
-	node->origin = ACTIONDFS_NODE_INPUT;
 	node->mode = mode;
 	mutex_init(&node->load_lock);
-	atomic64_set(&node->stage_generation, 0);
 	return node;
 }
 
@@ -952,7 +950,6 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_children *child
 	}
 
 	child = &children->entries[children->count];
-	memset(child, 0, sizeof(*child));
 	child->name = kmalloc(name_len + 1 + (target ? size + 1 : 0),
 			      GFP_KERNEL);
 	if (!child->name)
@@ -1677,7 +1674,8 @@ static int actiondfs_parse_reapi_digest(const u8 *data, size_t len,
 	size_t pos = 0;
 	int err;
 
-	memset(digest, 0, sizeof(*digest));
+	digest->hash[0] = '\0';
+	digest->size = 0;
 	while (pos < len) {
 		const u8 *field;
 		size_t field_len;
@@ -1974,7 +1972,7 @@ static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 	struct actiondfs_blob_path_cache_entry *existing;
 	unsigned long key;
 
-	entry = kzalloc(sizeof(*entry), GFP_KERNEL);
+	entry = kmalloc(sizeof(*entry), GFP_KERNEL);
 	if (!entry) {
 		path_get(path);
 		*out = *path;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -73,20 +73,20 @@ struct actiondfs_cached_child {
 	char hash[ACTIONDFS_HASH_HEX_LEN + 1];
 };
 
+struct actiondfs_cached_children {
+	struct actiondfs_cached_child *entries;
+	size_t count;
+	size_t capacity;
+};
+
 struct actiondfs_cached_dir {
 	struct hlist_node hnode;
 	struct dentry *cas_root;
 	char hash[ACTIONDFS_HASH_HEX_LEN + 1];
 	u64 size;
-	struct actiondfs_cached_child *file_children;
-	size_t file_count;
-	size_t file_capacity;
-	struct actiondfs_cached_child *dir_children;
-	size_t dir_count;
-	size_t dir_capacity;
-	struct actiondfs_cached_child *symlink_children;
-	size_t symlink_count;
-	size_t symlink_capacity;
+	struct actiondfs_cached_children files;
+	struct actiondfs_cached_children dirs;
+	struct actiondfs_cached_children symlinks;
 };
 
 struct actiondfs_blob_path_cache_entry {
@@ -715,15 +715,15 @@ static int actiondfs_compare_name(const char *lhs, size_t lhs_len,
 }
 
 static struct actiondfs_cached_child *
-actiondfs_find_cached_child_in(struct actiondfs_cached_child *children,
-			       size_t count, const char *name, size_t len)
+actiondfs_find_cached_child_in(struct actiondfs_cached_children *children,
+			       const char *name, size_t len)
 {
 	size_t lo = 0;
-	size_t hi = count;
+	size_t hi = children->count;
 
 	while (lo < hi) {
 		size_t mid = lo + (hi - lo) / 2;
-		struct actiondfs_cached_child *child = &children[mid];
+		struct actiondfs_cached_child *child = &children->entries[mid];
 		int cmp = actiondfs_compare_name(child->name, child->name_len,
 						 name, len);
 
@@ -748,16 +748,13 @@ actiondfs_find_cached_child(struct actiondfs_node *dir,
 	if (!cached)
 		return NULL;
 
-	child = actiondfs_find_cached_child_in(cached->file_children,
-					      cached->file_count, name, len);
+	child = actiondfs_find_cached_child_in(&cached->files, name, len);
 	if (child)
 		return child;
-	child = actiondfs_find_cached_child_in(cached->dir_children,
-					      cached->dir_count, name, len);
+	child = actiondfs_find_cached_child_in(&cached->dirs, name, len);
 	if (child)
 		return child;
-	return actiondfs_find_cached_child_in(cached->symlink_children,
-					      cached->symlink_count, name, len);
+	return actiondfs_find_cached_child_in(&cached->symlinks, name, len);
 }
 
 static struct actiondfs_node *
@@ -783,20 +780,27 @@ actiondfs_materialize_cached_child(struct actiondfs_node *parent,
 }
 
 static bool actiondfs_cached_children_overlap(
-	const struct actiondfs_cached_child *lhs, size_t lhs_count,
-	const struct actiondfs_cached_child *rhs, size_t rhs_count)
+	const struct actiondfs_cached_children *lhs,
+	const struct actiondfs_cached_children *rhs)
 {
+	const struct actiondfs_cached_child *lhs_entry = lhs->entries;
+	const struct actiondfs_cached_child *rhs_entry = rhs->entries;
+	size_t lhs_count = lhs->count;
+	size_t rhs_count = rhs->count;
+
 	while (lhs_count && rhs_count) {
-		int cmp = actiondfs_compare_name(lhs->name, lhs->name_len,
-						 rhs->name, rhs->name_len);
+		int cmp = actiondfs_compare_name(lhs_entry->name,
+						 lhs_entry->name_len,
+						 rhs_entry->name,
+						 rhs_entry->name_len);
 
 		if (!cmp)
 			return true;
 		if (cmp < 0) {
-			lhs++;
+			lhs_entry++;
 			lhs_count--;
 		} else {
-			rhs++;
+			rhs_entry++;
 			rhs_count--;
 		}
 	}
@@ -806,18 +810,9 @@ static bool actiondfs_cached_children_overlap(
 static int
 actiondfs_validate_no_cross_type_cached_duplicates(struct actiondfs_cached_dir *dir)
 {
-	if (actiondfs_cached_children_overlap(dir->file_children,
-					      dir->file_count,
-					      dir->dir_children,
-					      dir->dir_count) ||
-	    actiondfs_cached_children_overlap(dir->file_children,
-					      dir->file_count,
-					      dir->symlink_children,
-					      dir->symlink_count) ||
-	    actiondfs_cached_children_overlap(dir->dir_children,
-					      dir->dir_count,
-					      dir->symlink_children,
-					      dir->symlink_count))
+	if (actiondfs_cached_children_overlap(&dir->files, &dir->dirs) ||
+	    actiondfs_cached_children_overlap(&dir->files, &dir->symlinks) ||
+	    actiondfs_cached_children_overlap(&dir->dirs, &dir->symlinks))
 		return -EEXIST;
 	return 0;
 }
@@ -835,25 +830,24 @@ static int actiondfs_valid_component(const char *name, size_t len)
 }
 
 static void actiondfs_free_cached_children(
-	struct actiondfs_cached_child *children, size_t count)
+	struct actiondfs_cached_children *children)
 {
 	size_t i;
 
-	for (i = 0; i < count; i++) {
-		kfree(children[i].name);
-		kfree(children[i].link_target);
+	for (i = 0; i < children->count; i++) {
+		kfree(children->entries[i].name);
+		kfree(children->entries[i].link_target);
 	}
-	kfree(children);
+	kfree(children->entries);
 }
 
 static void actiondfs_free_cached_dir(struct actiondfs_cached_dir *dir)
 {
 	if (!dir)
 		return;
-	actiondfs_free_cached_children(dir->file_children, dir->file_count);
-	actiondfs_free_cached_children(dir->dir_children, dir->dir_count);
-	actiondfs_free_cached_children(dir->symlink_children,
-				       dir->symlink_count);
+	actiondfs_free_cached_children(&dir->files);
+	actiondfs_free_cached_children(&dir->dirs);
+	actiondfs_free_cached_children(&dir->symlinks);
 	if (dir->cas_root)
 		dput(dir->cas_root);
 	kfree(dir);
@@ -919,16 +913,14 @@ static void actiondfs_destroy_blob_path_cache(void)
 	mutex_unlock(&actiondfs_blob_path_cache_lock);
 }
 
-static int actiondfs_append_cached_child(struct actiondfs_cached_child **children_ptr,
-					 size_t *count,
-					 size_t *capacity_ptr,
+static int actiondfs_append_cached_child(struct actiondfs_cached_children *children,
 					 const char *name,
 					 size_t name_len,
 					 umode_t mode,
 					 u64 size,
 					 const char *hash)
 {
-	struct actiondfs_cached_child *children;
+	struct actiondfs_cached_child *entries;
 	struct actiondfs_cached_child *child;
 	size_t capacity;
 	int err;
@@ -936,26 +928,26 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_child **childre
 	err = actiondfs_valid_component(name, name_len);
 	if (err)
 		return err;
-	if (*count) {
-		child = &(*children_ptr)[*count - 1];
+	if (children->count) {
+		child = &children->entries[children->count - 1];
 		if (actiondfs_compare_name(child->name, child->name_len,
 					   name, name_len) >= 0)
 			return -EINVAL;
 	}
 
-	if (*count == *capacity_ptr) {
-		if (*capacity_ptr > SIZE_MAX / 2)
+	if (children->count == children->capacity) {
+		if (children->capacity > SIZE_MAX / 2)
 			return -EOVERFLOW;
-		capacity = *capacity_ptr ? *capacity_ptr * 2 : 8;
-		children = krealloc_array(*children_ptr, capacity,
-					  sizeof(*children), GFP_KERNEL);
-		if (!children)
+		capacity = children->capacity ? children->capacity * 2 : 8;
+		entries = krealloc_array(children->entries, capacity,
+					 sizeof(*entries), GFP_KERNEL);
+		if (!entries)
 			return -ENOMEM;
-		*children_ptr = children;
-		*capacity_ptr = capacity;
+		children->entries = entries;
+		children->capacity = capacity;
 	}
 
-	child = &(*children_ptr)[*count];
+	child = &children->entries[children->count];
 	memset(child, 0, sizeof(*child));
 	child->name = kmemdup_nul(name, name_len, GFP_KERNEL);
 	if (!child->name)
@@ -964,7 +956,7 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_child **childre
 	child->mode = mode;
 	child->size = size;
 	actiondfs_copy_hash(child->hash, hash);
-	(*count)++;
+	children->count++;
 	return 0;
 }
 
@@ -981,20 +973,18 @@ static int actiondfs_append_cached_symlink_child(struct actiondfs_cached_dir *pa
 	    memchr(target, '\0', target_len))
 		return -EINVAL;
 
-	err = actiondfs_append_cached_child(&parent->symlink_children,
-					    &parent->symlink_count,
-					    &parent->symlink_capacity,
+	err = actiondfs_append_cached_child(&parent->symlinks,
 					    name, name_len, S_IFLNK | 0777,
 					    target_len, ACTIONDFS_EMPTY_SHA256);
 	if (err)
 		return err;
 
-	child = &parent->symlink_children[parent->symlink_count - 1];
+	child = &parent->symlinks.entries[parent->symlinks.count - 1];
 	child->link_target = kmemdup_nul(target, target_len, GFP_KERNEL);
 	if (!child->link_target) {
 		kfree(child->name);
 		child->name = NULL;
-		parent->symlink_count--;
+		parent->symlinks.count--;
 		return -ENOMEM;
 	}
 	return 0;
@@ -1812,9 +1802,7 @@ static int actiondfs_parse_reapi_cached_file(struct actiondfs_cached_dir *parent
 	if (err)
 		return err;
 
-	err = actiondfs_append_cached_child(&parent->file_children,
-					    &parent->file_count,
-					    &parent->file_capacity,
+	err = actiondfs_append_cached_child(&parent->files,
 					    file.name, file.name_len,
 					    S_IFREG | (file.executable ? 0555 : 0444),
 					    file.digest.size, file.digest.hash);
@@ -1833,9 +1821,7 @@ static int actiondfs_parse_reapi_cached_dir(struct actiondfs_cached_dir *parent,
 	if (err)
 		return err;
 
-	err = actiondfs_append_cached_child(&parent->dir_children,
-					    &parent->dir_count,
-					    &parent->dir_capacity,
+	err = actiondfs_append_cached_child(&parent->dirs,
 					    dir.name, dir.name_len,
 					    S_IFDIR | ACTIONDFS_DIR_MODE,
 					    dir.digest.size, dir.digest.hash);
@@ -3320,13 +3306,14 @@ static int actiondfs_dir_release(struct inode *inode, struct file *file)
 
 static bool actiondfs_emit_cached_children(
 	struct actiondfs_node *dir, struct dir_context *ctx,
-	struct actiondfs_cached_child *children, size_t count,
+	struct actiondfs_cached_children *children,
 	loff_t *base, unsigned int d_type)
 {
-	size_t index = actiondfs_readdir_start_index(ctx->pos, *base, count);
+	size_t index = actiondfs_readdir_start_index(ctx->pos, *base,
+						     children->count);
 
-	for (; index < count; index++) {
-		struct actiondfs_cached_child *child = &children[index];
+	for (; index < children->count; index++) {
+		struct actiondfs_cached_child *child = &children->entries[index];
 
 		if (!dir_emit(ctx, child->name, child->name_len,
 			      actiondfs_input_child_ino(dir, child->name,
@@ -3337,7 +3324,7 @@ static bool actiondfs_emit_cached_children(
 		actiondfs_stat_inc(ACTIONDFS_STAT_READDIR_ENTRIES);
 		ctx->pos = *base + index + 1;
 	}
-	*base += count;
+	*base += children->count;
 	return true;
 }
 
@@ -3366,17 +3353,11 @@ static int actiondfs_iterate_shared(struct file *file, struct dir_context *ctx)
 	if (dir->cached_dir) {
 		struct actiondfs_cached_dir *cached = dir->cached_dir;
 
-		if (!actiondfs_emit_cached_children(dir, ctx,
-						   cached->file_children,
-						   cached->file_count,
+		if (!actiondfs_emit_cached_children(dir, ctx, &cached->files,
 						   &base, DT_REG) ||
-		    !actiondfs_emit_cached_children(dir, ctx,
-						   cached->dir_children,
-						   cached->dir_count,
+		    !actiondfs_emit_cached_children(dir, ctx, &cached->dirs,
 						   &base, DT_DIR) ||
-		    !actiondfs_emit_cached_children(dir, ctx,
-						   cached->symlink_children,
-						   cached->symlink_count,
+		    !actiondfs_emit_cached_children(dir, ctx, &cached->symlinks,
 						   &base, DT_LNK))
 			return 0;
 	}
@@ -3441,11 +3422,11 @@ static int actiondfs_dir_getattr(struct mnt_idmap *idmap,
 		return 0;
 	}
 
-	if (cached->dir_count > UINT_MAX - 2) {
+	if (cached->dirs.count > UINT_MAX - 2) {
 		stat->nlink = 1;
 		return 0;
 	}
-	input_dir_count = cached->dir_count;
+	input_dir_count = cached->dirs.count;
 	if (!stage_dentry || backing_nlink == 2)
 		stat->nlink = 2 + input_dir_count;
 	else if (!input_dir_count)

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2851,27 +2851,19 @@ out_put_inode:
 	return ERR_PTR(err);
 }
 
-static int actiondfs_unlink(struct inode *dir, struct dentry *dentry)
+static int actiondfs_remove_staged_child(struct inode *dir,
+					 struct dentry *dentry, bool directory)
 {
 	struct inode *inode = d_inode(dentry);
-	struct actiondfs_node *node = inode->i_private;
 	struct actiondfs_node *parent = dir->i_private;
 	struct actiondfs_sb_info *sbi = actiondfs_sbi(dir->i_sb);
 	struct path parent_path;
 	struct dentry *real_dentry;
 	int err;
 
-	if (node->origin != ACTIONDFS_NODE_STAGED)
-		return -EROFS;
-	if (S_ISDIR(node->mode))
-		return -EISDIR;
-
-	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_UNLINK_CALLS);
 	err = actiondfs_stage_node_path(sbi, parent, &parent_path);
-	if (err) {
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_UNLINK_FAILURES);
+	if (err)
 		return err;
-	}
 	err = mnt_want_write(parent_path.mnt);
 	if (err)
 		goto out_put_path;
@@ -2881,6 +2873,9 @@ static int actiondfs_unlink(struct inode *dir, struct dentry *dentry)
 		goto out_drop_write;
 	if (!d_inode(real_dentry)) {
 		err = -ENOENT;
+	} else if (directory) {
+		err = vfs_rmdir(mnt_idmap(parent_path.mnt),
+				d_inode(parent_path.dentry), real_dentry);
 	} else {
 		err = vfs_unlink(mnt_idmap(parent_path.mnt),
 				 d_inode(parent_path.dentry), real_dentry,
@@ -2889,27 +2884,37 @@ static int actiondfs_unlink(struct inode *dir, struct dentry *dentry)
 	actiondfs_stage_unlock_child(&parent_path, real_dentry);
 	if (!err) {
 		clear_nlink(inode);
+		if (directory)
+			drop_nlink(dir);
 		actiondfs_note_stage_change(parent);
 	}
 out_drop_write:
 	mnt_drop_write(parent_path.mnt);
 out_put_path:
 	path_put(&parent_path);
-	if (err)
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_UNLINK_FAILURES);
-	else
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_UNLINK_SUCCESS);
+	return err;
+}
+
+static int actiondfs_unlink(struct inode *dir, struct dentry *dentry)
+{
+	struct actiondfs_node *node = d_inode(dentry)->i_private;
+	int err;
+
+	if (node->origin != ACTIONDFS_NODE_STAGED)
+		return -EROFS;
+	if (S_ISDIR(node->mode))
+		return -EISDIR;
+
+	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_UNLINK_CALLS);
+	err = actiondfs_remove_staged_child(dir, dentry, false);
+	actiondfs_stat_inc(err ? ACTIONDFS_STAT_STAGE_UNLINK_FAILURES :
+			  ACTIONDFS_STAT_STAGE_UNLINK_SUCCESS);
 	return err;
 }
 
 static int actiondfs_rmdir(struct inode *dir, struct dentry *dentry)
 {
-	struct inode *inode = d_inode(dentry);
-	struct actiondfs_node *node = inode->i_private;
-	struct actiondfs_node *parent = dir->i_private;
-	struct actiondfs_sb_info *sbi = actiondfs_sbi(dir->i_sb);
-	struct path parent_path;
-	struct dentry *real_dentry;
+	struct actiondfs_node *node = d_inode(dentry)->i_private;
 	int err;
 
 	if (node->origin != ACTIONDFS_NODE_STAGED)
@@ -2920,38 +2925,9 @@ static int actiondfs_rmdir(struct inode *dir, struct dentry *dentry)
 		return -EROFS;
 
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_RMDIR_CALLS);
-	err = actiondfs_stage_node_path(sbi, parent, &parent_path);
-	if (err) {
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_RMDIR_FAILURES);
-		return err;
-	}
-	err = mnt_want_write(parent_path.mnt);
-	if (err)
-		goto out_put_path;
-	err = actiondfs_stage_lookup_child(&parent_path, dentry->d_name.name,
-					   dentry->d_name.len, &real_dentry);
-	if (err)
-		goto out_drop_write;
-	if (!d_inode(real_dentry)) {
-		err = -ENOENT;
-	} else {
-		err = vfs_rmdir(mnt_idmap(parent_path.mnt),
-				d_inode(parent_path.dentry), real_dentry);
-	}
-	actiondfs_stage_unlock_child(&parent_path, real_dentry);
-	if (!err) {
-		clear_nlink(inode);
-		drop_nlink(dir);
-		actiondfs_note_stage_change(parent);
-	}
-out_drop_write:
-	mnt_drop_write(parent_path.mnt);
-out_put_path:
-	path_put(&parent_path);
-	if (err)
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_RMDIR_FAILURES);
-	else
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_RMDIR_SUCCESS);
+	err = actiondfs_remove_staged_child(dir, dentry, true);
+	actiondfs_stat_inc(err ? ACTIONDFS_STAT_STAGE_RMDIR_FAILURES :
+			  ACTIONDFS_STAT_STAGE_RMDIR_SUCCESS);
 	return err;
 }
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1792,58 +1792,37 @@ static int actiondfs_parse_reapi_child_fields(const u8 *data, size_t len,
 	return out->digest.hash[0] ? 0 : -EINVAL;
 }
 
-static int actiondfs_parse_reapi_cached_file(struct actiondfs_cached_dir *parent,
-					     const u8 *data, size_t len)
+static int actiondfs_parse_reapi_cached_child(struct actiondfs_cached_dir *parent,
+					      const u8 *data, size_t len,
+					      umode_t mode)
 {
-	struct actiondfs_parsed_child file;
+	struct actiondfs_parsed_child child;
+	struct actiondfs_cached_children *children;
 	int err;
 
-	err = actiondfs_parse_reapi_child_fields(data, len, &file, S_IFREG);
+	err = actiondfs_parse_reapi_child_fields(data, len, &child, mode);
 	if (err)
 		return err;
+	if (S_ISLNK(mode))
+		return actiondfs_append_cached_symlink_child(
+			parent, child.name, child.name_len, child.symlink.target,
+			child.symlink.target_len);
 
-	err = actiondfs_append_cached_child(&parent->files,
-					    file.name, file.name_len,
-					    S_IFREG | (file.executable ? 0555 : 0444),
-					    file.digest.size, file.digest.hash);
+	if (S_ISREG(mode)) {
+		children = &parent->files;
+		mode |= child.executable ? 0555 : 0444;
+	} else {
+		children = &parent->dirs;
+		mode |= ACTIONDFS_DIR_MODE;
+	}
+	err = actiondfs_append_cached_child(children, child.name, child.name_len,
+					    mode, child.digest.size,
+					    child.digest.hash);
 	if (!err)
-		actiondfs_stat_inc(ACTIONDFS_STAT_CACHED_FILE_RECORDS);
+		actiondfs_stat_inc(S_ISREG(mode) ?
+				  ACTIONDFS_STAT_CACHED_FILE_RECORDS :
+				  ACTIONDFS_STAT_CACHED_DIR_RECORDS);
 	return err;
-}
-
-static int actiondfs_parse_reapi_cached_dir(struct actiondfs_cached_dir *parent,
-					    const u8 *data, size_t len)
-{
-	struct actiondfs_parsed_child dir;
-	int err;
-
-	err = actiondfs_parse_reapi_child_fields(data, len, &dir, S_IFDIR);
-	if (err)
-		return err;
-
-	err = actiondfs_append_cached_child(&parent->dirs,
-					    dir.name, dir.name_len,
-					    S_IFDIR | ACTIONDFS_DIR_MODE,
-					    dir.digest.size, dir.digest.hash);
-	if (!err)
-		actiondfs_stat_inc(ACTIONDFS_STAT_CACHED_DIR_RECORDS);
-	return err;
-}
-
-static int actiondfs_parse_reapi_cached_symlink(struct actiondfs_cached_dir *parent,
-						const u8 *data, size_t len)
-{
-	struct actiondfs_parsed_child symlink;
-	int err;
-
-	err = actiondfs_parse_reapi_child_fields(data, len, &symlink, S_IFLNK);
-	if (err)
-		return err;
-	return actiondfs_append_cached_symlink_child(parent,
-							     symlink.name,
-							     symlink.name_len,
-							     symlink.symlink.target,
-							     symlink.symlink.target_len);
 }
 
 static int actiondfs_read_cas_blob_once(struct actiondfs_sb_info *sbi,
@@ -2148,15 +2127,10 @@ static int actiondfs_build_cached_dir(struct actiondfs_sb_info *sbi,
 						    &field_len);
 			if (err)
 				goto out_buffer;
-			if ((key >> 3) == 1)
-				err = actiondfs_parse_reapi_cached_file(entry, field,
-								     field_len);
-			else if ((key >> 3) == 2)
-				err = actiondfs_parse_reapi_cached_dir(entry, field,
-								    field_len);
-			else
-				err = actiondfs_parse_reapi_cached_symlink(entry, field,
-								        field_len);
+			err = actiondfs_parse_reapi_cached_child(
+				entry, field, field_len,
+				(key >> 3) == 1 ? S_IFREG :
+				(key >> 3) == 2 ? S_IFDIR : S_IFLNK);
 			if (err)
 				goto out_buffer;
 			break;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2409,7 +2409,7 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	struct path parent_path;
 	struct dentry *real_dentry;
 	struct inode *real_inode;
-	struct inode *inode;
+	struct inode *inode = NULL;
 	struct actiondfs_node *node;
 	char *link_target = NULL;
 	umode_t mode;
@@ -2440,12 +2440,8 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_ERRORS);
 		return ERR_PTR(err);
 	}
-	if (!d_inode(real_dentry)) {
-		actiondfs_stage_unlock_child(&parent_path, real_dentry);
-		path_put(&parent_path);
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_NEGATIVE);
-		return NULL;
-	}
+	if (!d_inode(real_dentry))
+		goto out_negative;
 
 	real_inode = d_inode(real_dentry);
 	mode = real_inode->i_mode;
@@ -2459,12 +2455,8 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 			err = actiondfs_get_cached_dir(sbi, input_child->hash,
 						       input_child->size,
 						       &input_cached);
-			if (err) {
-				actiondfs_stage_unlock_child(&parent_path, real_dentry);
-				path_put(&parent_path);
-				actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_ERRORS);
-				return ERR_PTR(err);
-			}
+			if (err)
+				goto out_error;
 		}
 	} else if (S_ISREG(mode)) {
 		mode = S_IFREG | (mode & 0777);
@@ -2472,18 +2464,11 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	} else if (S_ISLNK(mode)) {
 		err = actiondfs_read_stage_symlink(real_dentry, &link_target,
 						    &size);
-		if (err) {
-			actiondfs_stage_unlock_child(&parent_path, real_dentry);
-			path_put(&parent_path);
-			actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_ERRORS);
-			return ERR_PTR(err);
-		}
+		if (err)
+			goto out_error;
 		mode = S_IFLNK | 0777;
 	} else {
-		actiondfs_stage_unlock_child(&parent_path, real_dentry);
-		path_put(&parent_path);
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_NEGATIVE);
-		return NULL;
+		goto out_negative;
 	}
 
 	if (merged_input) {
@@ -2500,40 +2485,46 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 		if (!node)
 			err = -ENOMEM;
 	}
-	if (!node) {
-		kfree(link_target);
-		actiondfs_stage_unlock_child(&parent_path, real_dentry);
-		path_put(&parent_path);
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_ERRORS);
-		return ERR_PTR(err);
-	}
+	if (!node)
+		goto out_error;
 	node->link_target = link_target;
+	link_target = NULL;
 	inode = actiondfs_iget(dir->i_sb, node);
 	if (IS_ERR(inode)) {
+		err = PTR_ERR(inode);
 		actiondfs_free_node(node);
-		actiondfs_stage_unlock_child(&parent_path, real_dentry);
-		path_put(&parent_path);
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_ERRORS);
-	} else {
-		if (inode->i_private != node) {
-			if (!merged_input)
-				actiondfs_free_node(node);
-			node = inode->i_private;
-		}
-		if (S_ISDIR(mode)) {
-			node->mode = mode;
-			inode->i_mode = mode;
-		}
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_HITS);
-		actiondfs_set_stage_dentry(node, real_dentry);
-		actiondfs_stage_unlock_child(&parent_path, real_dentry);
-		path_put(&parent_path);
+		goto out_error;
 	}
-	if (!IS_ERR(inode) && merged_input) {
+	if (inode->i_private != node) {
+		if (!merged_input)
+			actiondfs_free_node(node);
+		node = inode->i_private;
+	}
+	if (S_ISDIR(mode)) {
+		node->mode = mode;
+		inode->i_mode = mode;
+	}
+	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_HITS);
+	actiondfs_set_stage_dentry(node, real_dentry);
+
+out_unlock:
+	actiondfs_stage_unlock_child(&parent_path, real_dentry);
+	path_put(&parent_path);
+	if (inode && !IS_ERR(inode) && merged_input) {
 		smp_store_release(&node->cached_dir, input_cached);
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_INPUT_DIR_MERGES);
 	}
 	return inode;
+
+out_negative:
+	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_NEGATIVE);
+	goto out_unlock;
+
+out_error:
+	kfree(link_target);
+	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_ERRORS);
+	inode = ERR_PTR(err);
+	goto out_unlock;
 }
 
 static struct dentry *actiondfs_lookup(struct inode *dir,

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2679,106 +2679,32 @@ static struct dentry *actiondfs_lookup(struct inode *dir,
 	return NULL;
 }
 
-static int actiondfs_create(struct mnt_idmap *idmap, struct inode *dir,
-				    struct dentry *dentry, umode_t mode, bool excl)
+static int actiondfs_create_staged_file(struct inode *dir,
+					struct dentry *dentry, umode_t mode,
+					const char *target, bool excl)
 {
 	struct actiondfs_node *parent = dir->i_private;
 	struct actiondfs_sb_info *sbi = actiondfs_sbi(dir->i_sb);
 	struct inode *inode;
 	struct path parent_path;
 	struct dentry *real_dentry;
+	size_t target_len = 0;
 	int err;
 
-	if (!sbi->stage_path.dentry)
-		return -EROFS;
-	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CREATE_CALLS);
-	err = actiondfs_ensure_loaded(dir->i_sb, parent);
-	if (err) {
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CREATE_FAILURES);
-		return err;
-	}
-	if (actiondfs_find_cached_child(parent, dentry->d_name.name,
-						dentry->d_name.len)) {
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CREATE_FAILURES);
-		return -EROFS;
-	}
-	inode = actiondfs_prealloc_staged_inode(dir->i_sb, parent,
-					       S_IFREG | (mode & 0777), NULL, 0);
-	if (IS_ERR(inode)) {
-		err = PTR_ERR(inode);
-		goto out_fail;
+	if (target) {
+		target_len = strnlen(target, PATH_MAX);
+		if (!target_len || target_len >= PATH_MAX)
+			return -EINVAL;
 	}
 
-	err = actiondfs_ensure_stage_parent_path(sbi, parent, dentry->d_parent,
-							 &parent_path);
-	if (err)
-		goto out_put_inode;
-	err = mnt_want_write(parent_path.mnt);
-	if (err)
-		goto out_put_path;
-	err = actiondfs_stage_lookup_child(&parent_path, dentry->d_name.name,
-					   dentry->d_name.len, &real_dentry);
-	if (err)
-		goto out_drop_write;
-	if (d_inode(real_dentry)) {
-		err = -EEXIST;
-		actiondfs_stage_unlock_child(&parent_path, real_dentry);
-		goto out_drop_write;
-	}
-	err = vfs_create(mnt_idmap(parent_path.mnt),
-			 d_inode(parent_path.dentry), real_dentry,
-			 mode & 0777, excl);
-	inode_unlock(d_inode(parent_path.dentry));
-	if (err) {
-		dput(real_dentry);
-		goto out_drop_write;
-	}
-	actiondfs_insert_staged_inode(inode, real_dentry);
-	dput(real_dentry);
-	d_instantiate(dentry, inode);
-	inode = NULL;
-	actiondfs_note_stage_change(parent);
-	err = 0;
-
-out_drop_write:
-	mnt_drop_write(parent_path.mnt);
-out_put_path:
-	path_put(&parent_path);
-out_put_inode:
-	if (inode)
-		iput(inode);
-out_fail:
-	if (err)
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CREATE_FAILURES);
-	else
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CREATE_SUCCESS);
-	return err;
-}
-
-static int actiondfs_symlink(struct mnt_idmap *idmap, struct inode *dir,
-			     struct dentry *dentry, const char *target)
-{
-	struct actiondfs_node *parent = dir->i_private;
-	struct actiondfs_sb_info *sbi = actiondfs_sbi(dir->i_sb);
-	struct inode *inode;
-	struct path parent_path;
-	struct dentry *real_dentry;
-	size_t target_len;
-	int err;
-
-	if (!sbi->stage_path.dentry)
-		return -EROFS;
-	target_len = strnlen(target, PATH_MAX);
-	if (!target_len || target_len >= PATH_MAX)
-		return -EINVAL;
 	err = actiondfs_ensure_loaded(dir->i_sb, parent);
 	if (err)
 		return err;
 	if (actiondfs_find_cached_child(parent, dentry->d_name.name,
 						dentry->d_name.len))
 		return -EROFS;
-	inode = actiondfs_prealloc_staged_inode(dir->i_sb, parent,
-					       S_IFLNK | 0777, target, target_len);
+	inode = actiondfs_prealloc_staged_inode(dir->i_sb, parent, mode,
+					       target, target_len);
 	if (IS_ERR(inode))
 		return PTR_ERR(inode);
 
@@ -2798,29 +2724,55 @@ static int actiondfs_symlink(struct mnt_idmap *idmap, struct inode *dir,
 		actiondfs_stage_unlock_child(&parent_path, real_dentry);
 		goto out_drop_write;
 	}
-	err = vfs_symlink(mnt_idmap(parent_path.mnt),
-			  d_inode(parent_path.dentry), real_dentry, target);
+	if (target)
+		err = vfs_symlink(mnt_idmap(parent_path.mnt),
+				  d_inode(parent_path.dentry), real_dentry,
+				  target);
+	else
+		err = vfs_create(mnt_idmap(parent_path.mnt),
+				 d_inode(parent_path.dentry), real_dentry,
+				 mode & 0777, excl);
 	inode_unlock(d_inode(parent_path.dentry));
-	if (err) {
-		dput(real_dentry);
-		goto out_drop_write;
-	}
-
-	actiondfs_insert_staged_inode(inode, real_dentry);
+	if (!err)
+		actiondfs_insert_staged_inode(inode, real_dentry);
 	dput(real_dentry);
+	if (err)
+		goto out_drop_write;
 	d_instantiate(dentry, inode);
 	inode = NULL;
 	actiondfs_note_stage_change(parent);
-	err = 0;
 
 out_drop_write:
 	mnt_drop_write(parent_path.mnt);
 out_put_path:
 	path_put(&parent_path);
 out_put_inode:
-	if (inode)
-		iput(inode);
+	iput(inode);
 	return err;
+}
+
+static int actiondfs_create(struct mnt_idmap *idmap, struct inode *dir,
+				    struct dentry *dentry, umode_t mode, bool excl)
+{
+	int err;
+
+	if (!actiondfs_sbi(dir->i_sb)->stage_path.dentry)
+		return -EROFS;
+	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CREATE_CALLS);
+	err = actiondfs_create_staged_file(dir, dentry,
+					  S_IFREG | (mode & 0777), NULL, excl);
+	actiondfs_stat_inc(err ? ACTIONDFS_STAT_STAGE_CREATE_FAILURES :
+			  ACTIONDFS_STAT_STAGE_CREATE_SUCCESS);
+	return err;
+}
+
+static int actiondfs_symlink(struct mnt_idmap *idmap, struct inode *dir,
+			     struct dentry *dentry, const char *target)
+{
+	if (!actiondfs_sbi(dir->i_sb)->stage_path.dentry)
+		return -EROFS;
+	return actiondfs_create_staged_file(dir, dentry, S_IFLNK | 0777,
+					    target, false);
 }
 
 static struct dentry *actiondfs_mkdir(struct mnt_idmap *idmap,

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1019,23 +1019,12 @@ static int actiondfs_append_cached_symlink_child(struct actiondfs_cached_dir *pa
 	return 0;
 }
 
-static int actiondfs_hex_nibble(char c)
-{
-	if (c >= '0' && c <= '9')
-		return c - '0';
-	if (c >= 'a' && c <= 'f')
-		return c - 'a' + 10;
-	if (c >= 'A' && c <= 'F')
-		return c - 'A' + 10;
-	return -1;
-}
-
 static int actiondfs_valid_hash(const char *hash)
 {
 	size_t i;
 
 	for (i = 0; i < ACTIONDFS_HASH_HEX_LEN; i++) {
-		if (actiondfs_hex_nibble(hash[i]) < 0)
+		if (hex_to_bin(hash[i]) < 0)
 			return -EINVAL;
 	}
 	return hash[ACTIONDFS_HASH_HEX_LEN] ? -EINVAL : 0;
@@ -1153,13 +1142,8 @@ static struct file *actiondfs_open_backing_cas_blob(struct actiondfs_sb_info *sb
 		actiondfs_stat_add_elapsed(ACTIONDFS_STAT_BLOB_OPEN_BACKING_PATH_NS,
 					   path_start);
 		if (err) {
-			if (!actiondfs_retry_open_stale(err, &stale_attempts)) {
-				actiondfs_stat_add_elapsed(
-					ACTIONDFS_STAT_BLOB_OPEN_BACKING_TOTAL_NS,
-					total_start);
-				return ERR_PTR(err);
-			}
-			continue;
+			file = ERR_PTR(err);
+			goto retry;
 		}
 
 		real_inode = d_inode(real_path.dentry);
@@ -1167,9 +1151,8 @@ static struct file *actiondfs_open_backing_cas_blob(struct actiondfs_sb_info *sb
 		if (!real_inode || !S_ISREG(real_inode->i_mode) ||
 		    real_size < 0 || (u64)real_size != expected_size) {
 			path_put(&real_path);
-			actiondfs_stat_add_elapsed(
-				ACTIONDFS_STAT_BLOB_OPEN_BACKING_TOTAL_NS, total_start);
-			return ERR_PTR(-EIO);
+			file = ERR_PTR(-EIO);
+			break;
 		}
 
 		open_start = actiondfs_stat_time_start();
@@ -1178,23 +1161,19 @@ static struct file *actiondfs_open_backing_cas_blob(struct actiondfs_sb_info *sb
 		actiondfs_stat_add_elapsed(ACTIONDFS_STAT_BLOB_OPEN_BACKING_FILE_NS,
 					   open_start);
 		path_put(&real_path);
-		if (!IS_ERR(file)) {
-			actiondfs_stat_add_elapsed(
-				ACTIONDFS_STAT_BLOB_OPEN_BACKING_TOTAL_NS,
-				total_start);
-			return file;
-		}
+		if (!IS_ERR(file))
+			break;
 
 		err = PTR_ERR(file);
 		if (err == -ESTALE)
 			actiondfs_drop_cached_blob_path(sbi, hash);
-		if (!actiondfs_retry_open_stale(err, &stale_attempts)) {
-			actiondfs_stat_add_elapsed(
-				ACTIONDFS_STAT_BLOB_OPEN_BACKING_TOTAL_NS,
-				total_start);
-			return file;
-		}
+retry:
+		if (!actiondfs_retry_open_stale(err, &stale_attempts))
+			break;
 	}
+	actiondfs_stat_add_elapsed(ACTIONDFS_STAT_BLOB_OPEN_BACKING_TOTAL_NS,
+				   total_start);
+	return file;
 }
 
 static struct file *actiondfs_get_node_blob_file(struct actiondfs_node *node,
@@ -1249,10 +1228,8 @@ static struct file *actiondfs_open_staged_backing(struct actiondfs_sb_info *sbi,
 
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_BACKING_OPEN_ATTEMPTS);
 	if (!sbi->stage_path.dentry) {
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_BACKING_OPEN_FAILURES);
-		actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_BACKING_OPEN_TOTAL_NS,
-					   total_start);
-		return ERR_PTR(-EROFS);
+		file = ERR_PTR(-EROFS);
+		goto out;
 	}
 
 	phase_start = actiondfs_stat_time_start();
@@ -1260,10 +1237,8 @@ static struct file *actiondfs_open_staged_backing(struct actiondfs_sb_info *sbi,
 	actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_BACKING_OPEN_LOOKUP_NS,
 				   phase_start);
 	if (err) {
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_BACKING_OPEN_FAILURES);
-		actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_BACKING_OPEN_TOTAL_NS,
-					   total_start);
-		return ERR_PTR(err);
+		file = ERR_PTR(err);
+		goto out;
 	}
 
 	phase_start = actiondfs_stat_time_start();
@@ -1272,6 +1247,7 @@ static struct file *actiondfs_open_staged_backing(struct actiondfs_sb_info *sbi,
 	actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_BACKING_OPEN_FILE_NS,
 				   phase_start);
 	path_put(&real_path);
+out:
 	if (IS_ERR(file))
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_BACKING_OPEN_FAILURES);
 	actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_BACKING_OPEN_TOTAL_NS,
@@ -1947,7 +1923,7 @@ static int actiondfs_read_cas_blob_once(struct actiondfs_sb_info *sbi,
 	}
 
 	nread = kernel_read(file, buffer, (size_t)size, &pos);
-	if (nread < 0 || nread != size) {
+	if (nread != size) {
 		err = nread < 0 ? nread : -EIO;
 		kvfree(buffer);
 		goto out_close;
@@ -1973,12 +1949,11 @@ static int actiondfs_read_cas_blob(struct actiondfs_sb_info *sbi,
 	unsigned int stale_attempts = 0;
 	int err;
 
-	while (true) {
+	do {
 		err = actiondfs_read_cas_blob_once(sbi, hash, expected_size,
 						   out, out_len);
-		if (!actiondfs_retry_stale(err, &stale_attempts))
-			return err;
-	}
+	} while (actiondfs_retry_stale(err, &stale_attempts));
+	return err;
 }
 
 static unsigned long actiondfs_digest_cache_key(const char *hash)
@@ -1987,7 +1962,7 @@ static unsigned long actiondfs_digest_cache_key(const char *hash)
 	size_t i;
 
 	for (i = 0; i < 2 * sizeof(key); i++)
-		key = (key << 4) | actiondfs_hex_nibble(hash[i]);
+		key = (key << 4) | hex_to_bin(hash[i]);
 	return key;
 }
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -105,12 +105,12 @@ enum actiondfs_node_origin {
 };
 
 struct actiondfs_node {
-	enum actiondfs_node_origin origin;
 	u64 ino;
-	umode_t mode;
 	u64 size;
-	char *link_target;
+	enum actiondfs_node_origin origin;
+	umode_t mode;
 	char hash[ACTIONDFS_HASH_HEX_LEN + 1];
+	char *link_target;
 	const struct actiondfs_cached_child *input_child;
 	struct mutex load_lock;
 	struct actiondfs_node *parent;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -66,7 +66,6 @@
 
 struct actiondfs_cached_child {
 	char *name;
-	char *link_target;
 	u64 size;
 	u16 name_len;
 	umode_t mode;
@@ -774,7 +773,7 @@ actiondfs_materialize_cached_child(struct actiondfs_node *parent,
 					     S_ISDIR(record->mode));
 	node->size = record->size;
 	if (S_ISLNK(record->mode))
-		node->link_target = record->link_target;
+		node->link_target = record->name + record->name_len + 1;
 	actiondfs_copy_hash(node->hash, record->hash);
 	return node;
 }
@@ -834,10 +833,8 @@ static void actiondfs_free_cached_children(
 {
 	size_t i;
 
-	for (i = 0; i < children->count; i++) {
+	for (i = 0; i < children->count; i++)
 		kfree(children->entries[i].name);
-		kfree(children->entries[i].link_target);
-	}
 	kfree(children->entries);
 }
 
@@ -924,7 +921,8 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_children *child
 					 size_t name_len,
 					 umode_t mode,
 					 u64 size,
-					 const char *hash)
+					 const char *hash,
+					 const char *target)
 {
 	struct actiondfs_cached_child *entries;
 	struct actiondfs_cached_child *child;
@@ -955,9 +953,16 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_children *child
 
 	child = &children->entries[children->count];
 	memset(child, 0, sizeof(*child));
-	child->name = kmemdup_nul(name, name_len, GFP_KERNEL);
+	child->name = kmalloc(name_len + 1 + (target ? size + 1 : 0),
+			      GFP_KERNEL);
 	if (!child->name)
 		return -ENOMEM;
+	memcpy(child->name, name, name_len);
+	child->name[name_len] = '\0';
+	if (target) {
+		memcpy(child->name + name_len + 1, target, size);
+		child->name[name_len + 1 + size] = '\0';
+	}
 	child->name_len = name_len;
 	child->mode = mode;
 	child->size = size;
@@ -972,28 +977,14 @@ static int actiondfs_append_cached_symlink_child(struct actiondfs_cached_dir *pa
 						 const char *target,
 						 size_t target_len)
 {
-	struct actiondfs_cached_child *child;
-	int err;
-
 	if (!target_len || target_len >= PATH_MAX ||
 	    memchr(target, '\0', target_len))
 		return -EINVAL;
 
-	err = actiondfs_append_cached_child(&parent->symlinks,
-					    name, name_len, S_IFLNK | 0777,
-					    target_len, ACTIONDFS_EMPTY_SHA256);
-	if (err)
-		return err;
-
-	child = &parent->symlinks.entries[parent->symlinks.count - 1];
-	child->link_target = kmemdup_nul(target, target_len, GFP_KERNEL);
-	if (!child->link_target) {
-		kfree(child->name);
-		child->name = NULL;
-		parent->symlinks.count--;
-		return -ENOMEM;
-	}
-	return 0;
+	return actiondfs_append_cached_child(&parent->symlinks,
+					     name, name_len, S_IFLNK | 0777,
+					     target_len, ACTIONDFS_EMPTY_SHA256,
+					     target);
 }
 
 static int actiondfs_valid_hash(const char *hash)
@@ -1823,7 +1814,7 @@ static int actiondfs_parse_reapi_cached_child(struct actiondfs_cached_dir *paren
 	}
 	err = actiondfs_append_cached_child(children, child.name, child.name_len,
 					    mode, child.digest.size,
-					    child.digest.hash);
+					    child.digest.hash, NULL);
 	if (!err)
 		actiondfs_stat_inc(S_ISREG(mode) ?
 				  ACTIONDFS_STAT_CACHED_FILE_RECORDS :

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -897,17 +897,23 @@ static void actiondfs_release_blob_path_cache_entry(
 	call_rcu(&entry->rcu, actiondfs_release_blob_path_cache_entry_rcu);
 }
 
+static void actiondfs_unlink_blob_path_cache_entry_locked(
+	struct actiondfs_blob_path_cache_entry *entry)
+{
+	hash_del_rcu(&entry->hnode);
+	list_del(&entry->list);
+	actiondfs_blob_path_cache_count--;
+}
+
 static void actiondfs_destroy_blob_path_cache(void)
 {
 	struct actiondfs_blob_path_cache_entry *entry;
-	struct hlist_node *tmp;
-	unsigned int bucket;
+	struct actiondfs_blob_path_cache_entry *next;
 
 	mutex_lock(&actiondfs_blob_path_cache_lock);
-	hash_for_each_safe(actiondfs_blob_path_cache, bucket, tmp, entry, hnode) {
-		hash_del_rcu(&entry->hnode);
-		list_del(&entry->list);
-		actiondfs_blob_path_cache_count--;
+	list_for_each_entry_safe(entry, next, &actiondfs_blob_path_cache_list,
+				 list) {
+		actiondfs_unlink_blob_path_cache_entry_locked(entry);
 		actiondfs_release_blob_path_cache_entry(entry);
 	}
 	mutex_unlock(&actiondfs_blob_path_cache_lock);
@@ -1963,9 +1969,7 @@ static void actiondfs_evict_blob_path_cache_one_locked(void)
 	if (!victim)
 		return;
 
-	hash_del_rcu(&victim->hnode);
-	list_del(&victim->list);
-	actiondfs_blob_path_cache_count--;
+	actiondfs_unlink_blob_path_cache_entry_locked(victim);
 	actiondfs_stat_inc(ACTIONDFS_STAT_BLOB_PATH_CACHE_EVICTIONS);
 	actiondfs_release_blob_path_cache_entry(victim);
 }
@@ -2055,11 +2059,8 @@ static void actiondfs_drop_cached_blob_path(struct actiondfs_sb_info *sbi,
 
 	mutex_lock(&actiondfs_blob_path_cache_lock);
 	entry = actiondfs_find_blob_path_cache_locked(sbi, hash);
-	if (entry) {
-		hash_del_rcu(&entry->hnode);
-		list_del(&entry->list);
-		actiondfs_blob_path_cache_count--;
-	}
+	if (entry)
+		actiondfs_unlink_blob_path_cache_entry_locked(entry);
 	mutex_unlock(&actiondfs_blob_path_cache_lock);
 	if (entry)
 		actiondfs_release_blob_path_cache_entry(entry);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -61,7 +61,6 @@
 #define ACTIONDFS_PROC_STATS "actiondfs_stats"
 #define ACTIONDFS_HASH_HEX_LEN 64
 #define ACTIONDFS_SHARDED_HASH_PATH_LEN (2 + 1 + ACTIONDFS_HASH_HEX_LEN)
-#define ACTIONDFS_MAX_STAGE_DEPTH ((PATH_MAX + 1) / 2)
 #define ACTIONDFS_EMPTY_SHA256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 #define ACTIONDFS_UNKNOWN_SIZE (~(u64)0)
 
@@ -112,8 +111,7 @@ struct actiondfs_node {
 	u64 size;
 	char *link_target;
 	char hash[ACTIONDFS_HASH_HEX_LEN + 1];
-	const char *input_name;
-	size_t input_name_len;
+	const struct actiondfs_cached_child *input_child;
 	struct mutex load_lock;
 	struct actiondfs_node *parent;
 	struct dentry *stage_dentry;
@@ -428,7 +426,8 @@ static void actiondfs_free_node(struct actiondfs_node *node)
 		return;
 	if (node->stage_dentry)
 		dput(node->stage_dentry);
-	kfree(node->link_target);
+	if (node->origin == ACTIONDFS_NODE_STAGED)
+		kfree(node->link_target);
 	kfree(node);
 }
 
@@ -590,19 +589,12 @@ out_drop_write:
 	return err;
 }
 
-struct actiondfs_stage_ancestor {
-	struct actiondfs_node *node;
-	struct dentry *dentry;
-};
-
 static int actiondfs_ensure_stage_parent_path(struct actiondfs_sb_info *sbi,
 					      struct actiondfs_node *node,
-					      struct dentry *dentry,
 					      struct path *path)
 {
-	struct actiondfs_stage_ancestor *ancestors;
+	struct actiondfs_node **ancestors;
 	struct actiondfs_node *ancestor_node;
-	struct dentry *ancestor_dentry;
 	struct path current_path;
 	size_t depth = 0;
 	size_t path_len = 0;
@@ -620,18 +612,17 @@ static int actiondfs_ensure_stage_parent_path(struct actiondfs_sb_info *sbi,
 	}
 
 	ancestor_node = node;
-	ancestor_dentry = dentry;
 	while (!smp_load_acquire(&ancestor_node->stage_dentry)) {
+		const struct actiondfs_cached_child *child;
 		size_t name_len;
 
-		if (!ancestor_node->parent ||
-		    ancestor_dentry->d_parent == ancestor_dentry) {
+		child = ancestor_node->input_child;
+		if (!ancestor_node->parent || !child) {
 			err = -ESTALE;
 			goto out_error;
 		}
-		name_len = ancestor_dentry->d_name.len;
+		name_len = child->name_len;
 		if (!name_len || name_len > NAME_MAX ||
-		    depth == ACTIONDFS_MAX_STAGE_DEPTH ||
 		    name_len + 1 > PATH_MAX - path_len) {
 			err = -ENAMETOOLONG;
 			goto out_error;
@@ -639,7 +630,6 @@ static int actiondfs_ensure_stage_parent_path(struct actiondfs_sb_info *sbi,
 		path_len += name_len + 1;
 		depth++;
 		ancestor_node = ancestor_node->parent;
-		ancestor_dentry = ancestor_dentry->d_parent;
 	}
 
 	ancestors = kcalloc(depth, sizeof(*ancestors), GFP_KERNEL);
@@ -648,12 +638,9 @@ static int actiondfs_ensure_stage_parent_path(struct actiondfs_sb_info *sbi,
 		goto out_error;
 	}
 	ancestor_node = node;
-	ancestor_dentry = dentry;
 	for (i = 0; i < depth; i++) {
-		ancestors[i].node = ancestor_node;
-		ancestors[i].dentry = ancestor_dentry;
+		ancestors[i] = ancestor_node;
 		ancestor_node = ancestor_node->parent;
-		ancestor_dentry = ancestor_dentry->d_parent;
 	}
 
 	err = actiondfs_stage_node_path(sbi, ancestor_node, &current_path);
@@ -661,30 +648,30 @@ static int actiondfs_ensure_stage_parent_path(struct actiondfs_sb_info *sbi,
 		goto out_free;
 
 	while (depth) {
-		struct actiondfs_stage_ancestor *ancestor = &ancestors[--depth];
+		struct actiondfs_node *ancestor = ancestors[--depth];
+		const struct actiondfs_cached_child *child =
+			ancestor->input_child;
 		struct path next_path;
 
-		if (smp_load_acquire(&ancestor->node->stage_dentry)) {
-			err = actiondfs_stage_node_path(sbi, ancestor->node,
+		if (smp_load_acquire(&ancestor->stage_dentry)) {
+			err = actiondfs_stage_node_path(sbi, ancestor,
 							  &next_path);
 		} else {
 			actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_ENSURE_DIR_COMPONENTS);
 			err = vfs_path_lookup(current_path.dentry, current_path.mnt,
-					      ancestor->dentry->d_name.name,
+					      child->name,
 					      LOOKUP_DIRECTORY | LOOKUP_NO_SYMLINKS |
 					      LOOKUP_NO_XDEV, &next_path);
 			if (err == -ENOENT) {
 				err = actiondfs_stage_mkdir_child(
-					&current_path,
-					ancestor->dentry->d_name.name,
-					ancestor->dentry->d_name.len,
-					ancestor->node->mode & S_IALLUGO);
+					&current_path, child->name, child->name_len,
+					ancestor->mode & S_IALLUGO);
 				if (!err) {
 					actiondfs_stat_inc(
 						ACTIONDFS_STAT_STAGE_ENSURE_DIR_CREATED);
 					err = vfs_path_lookup(
 						current_path.dentry, current_path.mnt,
-						ancestor->dentry->d_name.name,
+						child->name,
 						LOOKUP_DIRECTORY | LOOKUP_NO_SYMLINKS |
 						LOOKUP_NO_XDEV, &next_path);
 				}
@@ -693,7 +680,7 @@ static int actiondfs_ensure_stage_parent_path(struct actiondfs_sb_info *sbi,
 					ACTIONDFS_STAT_STAGE_ENSURE_DIR_EXISTING);
 			}
 			if (!err)
-				actiondfs_set_stage_dentry(ancestor->node,
+				actiondfs_set_stage_dentry(ancestor,
 							  next_path.dentry);
 		}
 		if (err) {
@@ -784,19 +771,13 @@ actiondfs_materialize_cached_child(struct actiondfs_node *parent,
 		return ERR_PTR(-ENOMEM);
 
 	node->parent = parent;
-	node->input_name = record->name;
-	node->input_name_len = record->name_len;
+	node->input_child = record;
 	node->ino = actiondfs_input_child_ino(parent, record->name,
 					     record->name_len,
 					     S_ISDIR(record->mode));
 	node->size = record->size;
-	if (S_ISLNK(record->mode)) {
-		node->link_target = kstrdup(record->link_target, GFP_KERNEL);
-		if (!node->link_target) {
-			actiondfs_free_node(node);
-			return ERR_PTR(-ENOMEM);
-		}
-	}
+	if (S_ISLNK(record->mode))
+		node->link_target = record->link_target;
 	actiondfs_copy_hash(node->hash, record->hash);
 	return node;
 }
@@ -2329,10 +2310,7 @@ static int actiondfs_test_input_inode(struct inode *inode, void *data)
 	return existing && existing->origin == ACTIONDFS_NODE_INPUT &&
 	       existing->ino == candidate->ino &&
 	       existing->parent == candidate->parent &&
-	       (existing->mode & S_IFMT) == (candidate->mode & S_IFMT) &&
-	       existing->input_name_len == candidate->input_name_len &&
-	       !memcmp(existing->input_name, candidate->input_name,
-		       candidate->input_name_len);
+	       existing->input_child == candidate->input_child;
 }
 
 static int actiondfs_set_input_inode(struct inode *inode, void *data)
@@ -2683,8 +2661,7 @@ static int actiondfs_create_staged_file(struct inode *dir,
 	if (IS_ERR(inode))
 		return PTR_ERR(inode);
 
-	err = actiondfs_ensure_stage_parent_path(sbi, parent, dentry->d_parent,
-							 &parent_path);
+	err = actiondfs_ensure_stage_parent_path(sbi, parent, &parent_path);
 	if (err)
 		goto out_put_inode;
 	err = mnt_want_write(parent_path.mnt);
@@ -2783,8 +2760,7 @@ static struct dentry *actiondfs_mkdir(struct mnt_idmap *idmap,
 		return ERR_PTR(err);
 	}
 
-	err = actiondfs_ensure_stage_parent_path(sbi, parent, dentry->d_parent,
-							 &parent_path);
+	err = actiondfs_ensure_stage_parent_path(sbi, parent, &parent_path);
 	if (err)
 		goto out_put_inode;
 	err = mnt_want_write(parent_path.mnt);
@@ -2943,7 +2919,6 @@ static int actiondfs_rename(struct mnt_idmap *idmap, struct inode *old_dir,
 	if (err)
 		goto out_done;
 	err = actiondfs_ensure_stage_parent_path(sbi, new_parent,
-						 new_dentry->d_parent,
 						 &new_parent_path);
 	if (err)
 		goto out_put_old_path;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -66,10 +66,10 @@
 
 struct actiondfs_cached_child {
 	char *name;
-	size_t name_len;
 	char *link_target;
-	umode_t mode;
 	u64 size;
+	u16 name_len;
+	umode_t mode;
 	char hash[ACTIONDFS_HASH_HEX_LEN + 1];
 };
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -74,15 +74,15 @@ struct actiondfs_cached_child {
 
 struct actiondfs_cached_children {
 	struct actiondfs_cached_child *entries;
-	size_t count;
-	size_t capacity;
+	u32 count;
+	u32 capacity;
 };
 
 struct actiondfs_cached_dir {
 	struct hlist_node hnode;
 	struct dentry *cas_root;
 	char hash[ACTIONDFS_HASH_HEX_LEN + 1];
-	u64 size;
+	u32 size;
 	struct actiondfs_cached_children files;
 	struct actiondfs_cached_children dirs;
 	struct actiondfs_cached_children symlinks;
@@ -926,7 +926,7 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_children *child
 {
 	struct actiondfs_cached_child *entries;
 	struct actiondfs_cached_child *child;
-	size_t capacity;
+	u32 capacity;
 	int err;
 
 	err = actiondfs_valid_component(name, name_len);
@@ -940,7 +940,7 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_children *child
 	}
 
 	if (children->count == children->capacity) {
-		if (children->capacity > SIZE_MAX / 2)
+		if (children->capacity > U32_MAX / 2)
 			return -EOVERFLOW;
 		capacity = children->capacity ? children->capacity * 2 : 8;
 		entries = krealloc_array(children->entries, capacity,

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1717,15 +1717,14 @@ struct actiondfs_reapi_digest {
 struct actiondfs_parsed_child {
 	const u8 *name;
 	size_t name_len;
-	struct actiondfs_reapi_digest digest;
+	union {
+		struct actiondfs_reapi_digest digest;
+		struct {
+			const u8 *target;
+			size_t target_len;
+		} symlink;
+	};
 	bool executable;
-};
-
-struct actiondfs_parsed_symlink {
-	const u8 *name;
-	size_t name_len;
-	const u8 *target;
-	size_t target_len;
 };
 
 static int actiondfs_parse_reapi_digest(const u8 *data, size_t len,
@@ -1781,7 +1780,7 @@ static int actiondfs_parse_reapi_digest(const u8 *data, size_t len,
 
 static int actiondfs_parse_reapi_child_fields(const u8 *data, size_t len,
 					      struct actiondfs_parsed_child *out,
-					      bool parse_executable)
+					      umode_t mode)
 {
 	size_t pos = 0;
 	int err;
@@ -1808,6 +1807,9 @@ static int actiondfs_parse_reapi_child_fields(const u8 *data, size_t len,
 			if ((key >> 3) == 1) {
 				out->name = field;
 				out->name_len = field_len;
+			} else if (S_ISLNK(mode)) {
+				out->symlink.target = field;
+				out->symlink.target_len = field_len;
 			} else {
 				err = actiondfs_parse_reapi_digest(field, field_len,
 								 &out->digest);
@@ -1816,7 +1818,7 @@ static int actiondfs_parse_reapi_child_fields(const u8 *data, size_t len,
 			}
 			break;
 		case 4:
-			if (!parse_executable) {
+			if (!S_ISREG(mode)) {
 				err = actiondfs_pb_skip(data, len, &pos, key & 7);
 				if (err)
 					return err;
@@ -1836,7 +1838,11 @@ static int actiondfs_parse_reapi_child_fields(const u8 *data, size_t len,
 		}
 	}
 
-	return out->name && out->digest.hash[0] ? 0 : -EINVAL;
+	if (!out->name)
+		return -EINVAL;
+	if (S_ISLNK(mode))
+		return out->symlink.target ? 0 : -EINVAL;
+	return out->digest.hash[0] ? 0 : -EINVAL;
 }
 
 static int actiondfs_parse_reapi_cached_file(struct actiondfs_cached_dir *parent,
@@ -1845,7 +1851,7 @@ static int actiondfs_parse_reapi_cached_file(struct actiondfs_cached_dir *parent
 	struct actiondfs_parsed_child file;
 	int err;
 
-	err = actiondfs_parse_reapi_child_fields(data, len, &file, true);
+	err = actiondfs_parse_reapi_child_fields(data, len, &file, S_IFREG);
 	if (err)
 		return err;
 
@@ -1866,7 +1872,7 @@ static int actiondfs_parse_reapi_cached_dir(struct actiondfs_cached_dir *parent,
 	struct actiondfs_parsed_child dir;
 	int err;
 
-	err = actiondfs_parse_reapi_child_fields(data, len, &dir, false);
+	err = actiondfs_parse_reapi_child_fields(data, len, &dir, S_IFDIR);
 	if (err)
 		return err;
 
@@ -1884,50 +1890,17 @@ static int actiondfs_parse_reapi_cached_dir(struct actiondfs_cached_dir *parent,
 static int actiondfs_parse_reapi_cached_symlink(struct actiondfs_cached_dir *parent,
 						const u8 *data, size_t len)
 {
-	struct actiondfs_parsed_symlink symlink = {};
-	size_t pos = 0;
+	struct actiondfs_parsed_child symlink;
 	int err;
 
-	while (pos < len) {
-		const u8 *field;
-		size_t field_len;
-		u64 key;
-
-		err = actiondfs_pb_read_varint(data, len, &pos, &key);
-		if (err)
-			return err;
-
-		switch (key >> 3) {
-		case 1:
-		case 2:
-			if ((key & 7) != 2)
-				return -EINVAL;
-			err = actiondfs_pb_read_len(data, len, &pos, &field,
-						   &field_len);
-			if (err)
-				return err;
-			if ((key >> 3) == 1) {
-				symlink.name = field;
-				symlink.name_len = field_len;
-			} else {
-				symlink.target = field;
-				symlink.target_len = field_len;
-			}
-			break;
-		default:
-			err = actiondfs_pb_skip(data, len, &pos, key & 7);
-			if (err)
-				return err;
-		}
-	}
-
-	if (!symlink.name || !symlink.target)
-		return -EINVAL;
+	err = actiondfs_parse_reapi_child_fields(data, len, &symlink, S_IFLNK);
+	if (err)
+		return err;
 	return actiondfs_append_cached_symlink_child(parent,
 							     symlink.name,
 							     symlink.name_len,
-							     symlink.target,
-							     symlink.target_len);
+							     symlink.symlink.target,
+							     symlink.symlink.target_len);
 }
 
 static int actiondfs_read_cas_blob_once(struct actiondfs_sb_info *sbi,


### PR DESCRIPTION
Five focused commits simplify shared REAPI child parsing; staged file/symlink creation; staged unlink/rmdir; backing opens and hexadecimal parsing; and immutable child identity, symlink ownership, and staged-directory ancestry. Removes 149 net lines from `kernel/actiondfs/actiondfs.c` and eight bytes per input node.

Validation: full ARM64/x86_64 production and instrumented kernel builds, `bazel build/test //...`, the standalone timing-parser test, production and instrumented `tools/e2e.sh vm`, and two fresh-worker LLVM smokes with identical 2,017 warmup plus 2,106 measured actions. Local LLVM times were distorted by severe host CPU/memory contention: 137.064/151.585 seconds and 166.200/196.180 seconds versus the prior 102.136/108.831 seconds; identical action digests and filesystem counters isolate the slowdown to action process scheduling.

All five GitHub Actions checks pass. The 1,998-action Linux comparison measured 275.435 seconds for actiond and 263.800 seconds natively (1.044×); the `main` baseline was 301.049/298.626 seconds (1.008×). The 1,998-action Windows comparison measured 355.531 seconds for actiond and 362.304 seconds natively (0.981×); the `main` baseline was 370.627/392.874 seconds (0.943×). The normalized ratios are approximately 3.6% slower on Linux and 4.0% slower on Windows. The Linux check initially reproduced the intermittent keepalive stall previously observed on `main`, then passed when only the failed job was rerun.
