### PR TITLE
actiondfs: simplify inode metadata, digest caching, and lookups

### DIFF
--- a/e2e/LLVM_VM_SMOKE_TIMINGS.md
+++ b/e2e/LLVM_VM_SMOKE_TIMINGS.md
@@ -27,25 +27,25 @@ subset of the VM `llvm-tblgen` graph.
 
 ## Latest Checked-In Result
 
-- Generated: `2026-07-31 21:55:41 EDT`
+- Generated: `2026-08-01 00:33:32 EDT`
 - Command: `ACTIOND_BAZEL_BUILD_FLAGS="--jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" ACTIOND_LLVM_SMOKE_MAC_HOST=0 e2e/run_llvm_vm_smoke.sh`
-- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.7m9AaQ`
+- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.4zlbWj`
 - Workload: `@llvm-project//llvm:llvm-tblgen`, jobs=8
 - VM warmup target: `//e2e:llvm_exec_warmup`
 - Target and VM host platform: `@llvm//platforms:linux_arm64_musl`
 - Build mode: `-c opt --strip=always --stripopt=--strip-all`
-- VM warmup: `97.329s`; `2207 processes: 190 internal, 2017 remote`
-- Measured VM build: `147.209s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
+- VM warmup: `154.225s`; `2207 processes: 190 internal, 2017 remote`
+- Measured VM build: `136.185s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
 - Measured executions and timing records: `2106`
 - Mac-host baseline: not run (`ACTIOND_LLVM_SMOKE_MAC_HOST=0`)
 
 The previous checked-in run used the same jobs=8 and completed the warmup in
-`112.244s` and measured build in `86.371s`. The current warmup is 13.3% faster
-with the same 2,017 warmup actions. A concurrent local Drake C++ compilation
-started during the measured build, so its `147.209s` elapsed time is not a
-matched comparison with the previous `86.371s` run. Both measured builds
-executed the same 2,106 actions. Compare matched CI actiond/native timings when
-host CPU or memory contention affects local VM measurements.
+`97.329s` and measured build in `147.209s`. The current measured build is 7.5%
+faster with the same 2,106 actions, while its warmup is 58.5% slower with the
+same 2,017 actions. Intermediate runs on the same machine completed the
+warmup/measured builds in `96.032s`/`104.393s` and `94.614s`/`180.238s`. The
+large changes between identical action sets coincide with host CPU and memory
+contention; compare matched CI actiond/native timings for performance changes.
 
 Earlier checked-in runs completed the warmup and measured build in
 `102.136s`/`108.831s` and `106.289s`/`138.481s`. A run before action isolation
@@ -59,22 +59,22 @@ Counters include both warmup and measured builds.
 
 | Counter                              | Prior       | Current     |
 | ------------------------------------ | ----------: | ----------: |
-| actiondfs mounts                     |       4,123 |       4,122 |
-| root directory parses                |       1,407 |       1,406 |
-| cached directory hits                |     163,036 |     163,007 |
-| cached directory misses              |       6,629 |       6,610 |
-| directory blob reads                 |       6,628 |       6,609 |
-| staged ensure-directory calls        |      16,001 |      15,994 |
+| actiondfs mounts                     |       4,122 |       4,123 |
+| root directory parses                |       1,406 |       1,406 |
+| cached directory hits                |     163,007 |     163,041 |
+| cached directory misses              |       6,610 |       6,624 |
+| directory blob reads                 |       6,609 |       6,623 |
+| staged ensure-directory calls        |      15,994 |      16,001 |
 | staged ensure-directory components   |          16 |          16 |
 | staged ensure-directory existing     |           0 |           0 |
 | staged ensure-directory created      |          16 |          16 |
-| staged parent dentry hits            |      15,985 |      15,978 |
-| blob-path cache hits                 |     460,969 |     460,692 |
-| blob-path cache misses               |       6,971 |       6,883 |
+| staged parent dentry hits            |      15,978 |      15,985 |
+| blob-path cache hits                 |     460,692 |     460,969 |
+| blob-path cache misses               |       6,883 |       6,971 |
 | blob-path cache evictions            |           0 |           0 |
-| blob-path cache insertion races      |           1 |           0 |
-| staged backing open attempts         |      15,828 |      15,824 |
-| staged backing open lookup           | 0.560 ms    | 0.648 ms    |
+| blob-path cache insertion races      |           0 |           1 |
+| staged backing open attempts         |      15,824 |      15,828 |
+| staged backing open lookup           | 0.648 ms    | 0.692 ms    |
 | staged `copy_file_range` successes   |       3,828 |       3,828 |
 | staged `copy_file_range` fallbacks   |           0 |           0 |
 
@@ -88,10 +88,10 @@ All timing values are milliseconds.
 
 | Stage                 |   Min |    p25 |    p50 |     p75 |      p95 |    Mean |       Max |
 | --------------------- | ----: | -----: | -----: | ------: | -------: | ------: | --------: |
-| total                 | 5.837 | 27.696 | 40.060 | 122.525 | 2616.169 | 477.553 | 17611.456 |
-| input fetch/setup     | 0.418 |  0.592 |  0.683 |   1.104 |    3.948 |   1.700 |   112.102 |
-| execute               | 5.098 | 25.931 | 37.629 | 118.874 | 2613.769 | 474.539 | 17608.027 |
-| output upload/collect | 0.023 |  0.132 |  0.213 |   1.259 |    4.853 |   1.315 |   133.861 |
+| total                 | 7.856 | 30.071 | 51.388 | 190.619 | 2488.708 | 437.578 | 11479.179 |
+| input fetch/setup     | 0.415 |  0.594 |  0.845 |   1.234 |    4.437 |   1.740 |   188.989 |
+| execute               | 7.088 | 28.012 | 48.725 | 183.730 | 2478.244 | 433.987 | 11469.574 |
+| output upload/collect | 0.020 |  0.145 |  0.294 |   1.587 |    6.432 |   1.851 |   161.902 |
 
 ## Runner Timing
 
@@ -101,12 +101,12 @@ and lazy actiondfs input reads. All timing values are milliseconds.
 
 | Runner Stage   |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | -------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| parent prepare | 0.059 |  0.096 |  0.126 |  0.167 |    0.546 |   0.365 |   110.160 |
-| fork           | 0.289 |  0.539 |  0.630 |  1.229 |   11.535 |   3.255 |   264.441 |
-| child setup    | 0.009 |  2.864 |  5.137 |  9.901 |   39.427 |  11.185 |   409.289 |
-| process/io     | 0.812 | 19.219 | 28.286 | 75.714 | 2591.701 | 459.093 | 17592.442 |
-| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    3.337 |   0.350 |    31.314 |
-| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.001 |     0.153 |
+| parent prepare | 0.056 |  0.102 |  0.132 |  0.214 |    0.632 |   0.423 |    96.043 |
+| fork           | 0.331 |  0.561 |  0.752 |  1.843 |   19.644 |   5.298 |   408.534 |
+| child setup    | 0.006 |  3.421 |  6.095 | 14.244 |   56.363 |  14.388 |   287.535 |
+| process/io     | 2.457 | 19.980 | 32.946 | 121.092 | 2467.317 | 413.121 | 11440.529 |
+| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    4.235 |   0.538 |    43.349 |
+| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.006 |     8.539 |
 
 ## actiondfs Counters
 
@@ -114,59 +114,59 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 
 | Counter                       |           Value |
 | ----------------------------- | --------------: |
-| mounts                        |           4,122 |
+| mounts                        |           4,123 |
 | root directory parses         |           1,406 |
-| cached directory requests     |         169,617 |
-| cached directory hits         |         163,007 |
-| cached directory misses       |           6,610 |
-| lookups                       |       1,406,667 |
-| lookup hits                   |         841,778 |
-| lookup negative               |         564,889 |
-| blob open attempts            |         474,184 |
-| blob-path cache hits          |         460,692 |
-| blob-path cache misses        |           6,883 |
+| cached directory requests     |         169,665 |
+| cached directory hits         |         163,041 |
+| cached directory misses       |           6,624 |
+| lookups                       |       1,407,099 |
+| lookup hits                   |         842,187 |
+| lookup negative               |         564,912 |
+| blob open attempts            |         474,563 |
+| blob-path cache hits          |         460,969 |
+| blob-path cache misses        |           6,971 |
 | blob-path cache evictions     |               0 |
-| blob-path cache insertion races |             0 |
-| node blob cache hits          |         472,190 |
-| node blob cache misses        |         467,575 |
-| backing reads                 |         415,332 |
-| backing read bytes            |   1,303,012,282 |
-| mmap calls                    |          53,030 |
-| mmap bytes                    | 1,900,832,624,640 |
+| blob-path cache insertion races |             1 |
+| node blob cache hits          |         472,567 |
+| node blob cache misses        |         467,940 |
+| backing reads                 |         415,500 |
+| backing read bytes            |   1,303,975,362 |
+| mmap calls                    |          53,239 |
+| mmap bytes                    | 1,901,676,589,056 |
 | mmap failures                 |               0 |
-| directory blob reads          |           6,609 |
-| directory blob bytes          |       2,720,612 |
+| directory blob reads          |           6,623 |
+| directory blob bytes          |       2,736,211 |
 
 ## Staged Filesystem Counters
 
 | Counter                              |       Value |
 | ------------------------------------ | ----------: |
-| staged ensure-directory calls        |      15,994 |
+| staged ensure-directory calls        |      16,001 |
 | staged ensure-directory components   |          16 |
 | staged ensure-directory existing     |           0 |
 | staged ensure-directory created      |          16 |
-| staged parent dentry hits            |      15,978 |
-| staged inode lookups                 |   1,406,667 |
-| staged inode unstaged-parent skips   |   1,331,308 |
-| staged inode lookup hits             |      35,518 |
-| staged inode lookup negative         |      39,841 |
-| staged inode input-directory merges  |      18,382 |
-| staged backing open attempts         |      15,824 |
+| staged parent dentry hits            |      15,985 |
+| staged inode lookups                 |   1,407,099 |
+| staged inode unstaged-parent skips   |   1,331,722 |
+| staged inode lookup hits             |      35,524 |
+| staged inode lookup negative         |      39,853 |
+| staged inode input-directory merges  |      18,388 |
+| staged backing open attempts         |      15,828 |
 | staged backing open failures         |           0 |
-| staged backing open total            |   12.551 ms |
-| staged backing open lookup           |    0.648 ms |
-| staged backing open file             |    9.859 ms |
-| staged create calls/successes        |      11,980 |
+| staged backing open total            |   13.080 ms |
+| staged backing open lookup           |    0.692 ms |
+| staged backing open file             |    9.727 ms |
+| staged create calls/successes        |      11,984 |
 | staged mkdir calls/successes         |         198 |
-| staged rename calls/successes        |       3,816 |
-| staged size updates/successes        |       3,874 |
-| staged write calls                   |      36,943 |
-| staged write bytes                   | 105,212,804 |
+| staged rename calls/successes        |       3,819 |
+| staged size updates/successes        |       3,876 |
+| staged write calls                   |      37,194 |
+| staged write bytes                   | 106,356,427 |
 | staged `copy_file_range` successes   |       3,828 |
 | staged `copy_file_range` bytes       |  31,630,764 |
 | staged `copy_file_range` fallbacks   |           0 |
 
-The staged-negative filter skipped 1,331,308 lookups with known-unstaged
+The staged-negative filter skipped 1,331,722 lookups with known-unstaged
 parents. All 3,828 `copy_file_range` attempts succeeded without a buffered
 fallback.
 
@@ -174,14 +174,14 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| CAS put-file calls                   |      7,946 |
-| CAS promotion attempts               |      7,946 |
-| CAS promotion success                |      2,086 |
+| CAS put-file calls                   |      7,949 |
+| CAS promotion attempts               |      7,949 |
+| CAS promotion success                |      2,089 |
 | CAS existing-blob hits               |      5,860 |
-| CAS promoted bytes                   | 31,268,199 |
-| CAS digest bytes                     | 83,602,151 |
-| CAS promotion digest                 | 792.857 ms |
-| CAS promotion rename                 | 147.752 ms |
+| CAS promoted bytes                   | 37,922,351 |
+| CAS digest bytes                     | 90,256,303 |
+| CAS promotion digest                 | 1,069.739 ms |
+| CAS promotion rename                 | 229.018 ms |
 | CAS cross-device fallbacks           |          0 |
 | CAS permission fallbacks             |          0 |
 | CAS put-file copy calls              |          0 |
@@ -190,19 +190,19 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| ByteStream file reads                |      4,037 |
-| ByteStream file bytes                | 57,511,165 |
+| ByteStream file reads                |      4,045 |
+| ByteStream file bytes                | 63,436,296 |
 | ByteStream buffered reads            |          0 |
-| gRPC response tasks started          |     36,228 |
+| gRPC response tasks started          |     36,255 |
 | gRPC response tasks failed           |          0 |
 | gRPC response concurrency waits      |          0 |
-| gRPC data frames                     |     37,003 |
-| gRPC file payload frames             |      6,895 |
-| gRPC `sendfile` attempts/successes   |      6,895 |
-| gRPC `sendfile` bytes                | 57,511,165 |
+| gRPC data frames                     |     37,395 |
+| gRPC file payload frames             |      7,263 |
+| gRPC `sendfile` attempts/successes   |      7,263 |
+| gRPC `sendfile` bytes                | 63,436,296 |
 | gRPC `sendfile` fallbacks            |          0 |
 
-The measured TCP-to-vsock bridge logged two connections, 28.23 MiB from client
-to guest, 37.37 MiB from guest to client, and zero read/write pump errors.
-ByteStream reads remained file-backed and all 6,895 gRPC `sendfile` attempts
+The measured TCP-to-vsock bridge logged two connections, 28.21 MiB from client
+to guest, 37.38 MiB from guest to client, and zero read/write pump errors.
+ByteStream reads remained file-backed and all 7,263 gRPC `sendfile` attempts
 succeeded.

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1950,7 +1950,6 @@ static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 
 	entry = kmalloc(sizeof(*entry), GFP_KERNEL);
 	if (!entry) {
-		path_get(path);
 		*out = *path;
 		return;
 	}
@@ -1966,6 +1965,7 @@ static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 		mutex_unlock(&actiondfs_blob_path_cache_lock);
 		actiondfs_stat_inc(ACTIONDFS_STAT_BLOB_PATH_CACHE_RACES);
 		actiondfs_free_blob_path_cache_entry(entry);
+		path_put(path);
 		return;
 	}
 
@@ -1977,7 +1977,7 @@ static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 	list_add_tail(&entry->list, &actiondfs_blob_path_cache_list);
 	actiondfs_blob_path_cache_count++;
 	actiondfs_stat_inc(ACTIONDFS_STAT_BLOB_PATH_CACHE_INSERTS);
-	actiondfs_get_blob_path_cache_entry_locked(sbi, entry, out);
+	*out = *path;
 	mutex_unlock(&actiondfs_blob_path_cache_lock);
 }
 
@@ -2011,7 +2011,6 @@ static int actiondfs_get_cached_blob_path(struct actiondfs_sb_info *sbi,
 		return err;
 
 	actiondfs_insert_blob_path_cache(sbi, hash, &real_path, out);
-	path_put(&real_path);
 	return 0;
 }
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -93,7 +93,7 @@ struct actiondfs_blob_path_cache_entry {
 	struct list_head list;
 	struct rcu_head rcu;
 	struct work_struct release_work;
-	char hash[ACTIONDFS_HASH_HEX_LEN + 1];
+	const char *hash;
 	struct dentry *cas_root;
 	struct dentry *dentry;
 };
@@ -1968,7 +1968,7 @@ static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 		return;
 	}
 
-	actiondfs_copy_hash(entry->hash, hash);
+	entry->hash = hash;
 	entry->cas_root = dget(sbi->cas_path.dentry);
 	entry->dentry = dget(path->dentry);
 	INIT_WORK(&entry->release_work,

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -110,13 +110,15 @@ struct actiondfs_node {
 	u64 size;
 	enum actiondfs_node_origin origin;
 	umode_t mode;
-	char *link_target;
+	union {
+		char *link_target;
+		atomic64_t stage_generation;
+	};
 	const struct actiondfs_cached_child *input_child;
 	struct mutex load_lock;
 	struct actiondfs_node *parent;
 	struct dentry *stage_dentry;
 	struct actiondfs_cached_dir *cached_dir;
-	atomic64_t stage_generation;
 };
 
 struct actiondfs_sb_info {
@@ -425,7 +427,7 @@ static void actiondfs_free_node(struct actiondfs_node *node)
 		return;
 	if (node->stage_dentry)
 		dput(node->stage_dentry);
-	if (node->origin == ACTIONDFS_NODE_STAGED)
+	if (node->origin == ACTIONDFS_NODE_STAGED && S_ISLNK(node->mode))
 		kfree(node->link_target);
 	kfree(node);
 }
@@ -2475,8 +2477,10 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	}
 	if (!node)
 		goto out_error;
-	node->link_target = link_target;
-	link_target = NULL;
+	if (S_ISLNK(mode)) {
+		node->link_target = link_target;
+		link_target = NULL;
+	}
 	inode = actiondfs_iget(dir->i_sb, node);
 	if (IS_ERR(inode)) {
 		err = PTR_ERR(inode);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -108,7 +108,7 @@ struct actiondfs_node {
 	u64 size;
 	enum actiondfs_node_origin origin;
 	umode_t mode;
-	char hash[ACTIONDFS_HASH_HEX_LEN + 1];
+	const char *hash;
 	char *link_target;
 	const struct actiondfs_cached_child *input_child;
 	struct mutex load_lock;
@@ -122,6 +122,7 @@ struct actiondfs_sb_info {
 	struct path cas_path;
 	struct path stage_path;
 	struct actiondfs_node *root;
+	char root_hash[ACTIONDFS_HASH_HEX_LEN + 1];
 };
 
 struct actiondfs_mount_options {
@@ -770,9 +771,9 @@ actiondfs_materialize_cached_child(struct actiondfs_node *parent,
 					     record->name_len,
 					     S_ISDIR(record->mode));
 	node->size = record->size;
+	node->hash = record->hash;
 	if (S_ISLNK(record->mode))
 		node->link_target = record->name + record->name_len + 1;
-	actiondfs_copy_hash(node->hash, record->hash);
 	return node;
 }
 
@@ -3492,7 +3493,8 @@ static int actiondfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	} else {
 		sb->s_flags |= SB_RDONLY;
 	}
-	actiondfs_copy_hash(sbi->root->hash, opts.root_hash);
+	actiondfs_copy_hash(sbi->root_hash, opts.root_hash);
+	sbi->root->hash = sbi->root_hash;
 	sbi->root->size = opts.root_size;
 
 	root_inode = actiondfs_iget(sb, sbi->root);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -91,8 +91,10 @@ struct actiondfs_cached_dir {
 struct actiondfs_blob_path_cache_entry {
 	struct hlist_node hnode;
 	struct list_head list;
-	struct rcu_head rcu;
-	struct work_struct release_work;
+	union {
+		struct rcu_head rcu;
+		struct work_struct release_work;
+	};
 	const char *hash;
 	struct dentry *cas_root;
 	struct dentry *dentry;
@@ -881,6 +883,8 @@ static void actiondfs_release_blob_path_cache_entry_rcu(struct rcu_head *rcu)
 	struct actiondfs_blob_path_cache_entry *entry =
 		container_of(rcu, struct actiondfs_blob_path_cache_entry, rcu);
 
+	INIT_WORK(&entry->release_work,
+		  actiondfs_release_blob_path_cache_entry_work);
 	queue_work(actiondfs_blob_path_cache_release_wq, &entry->release_work);
 }
 
@@ -1971,8 +1975,6 @@ static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 	entry->hash = hash;
 	entry->cas_root = dget(sbi->cas_path.dentry);
 	entry->dentry = dget(path->dentry);
-	INIT_WORK(&entry->release_work,
-		  actiondfs_release_blob_path_cache_entry_work);
 
 	mutex_lock(&actiondfs_blob_path_cache_lock);
 	existing = actiondfs_find_blob_path_cache_locked(sbi, hash);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2388,13 +2388,6 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	bool merged_input = false;
 	int err;
 
-	if (!sbi->stage_path.dentry)
-		return NULL;
-	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUPS);
-	if (!READ_ONCE(parent->stage_dentry)) {
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_UNSTAGED_PARENT);
-		return NULL;
-	}
 	err = actiondfs_stage_node_path(sbi, parent, &parent_path);
 	if (err) {
 		if (err == -ENOENT) {
@@ -2504,6 +2497,7 @@ static struct dentry *actiondfs_lookup(struct inode *dir,
 				       struct dentry *dentry,
 				       unsigned int flags)
 {
+	struct actiondfs_sb_info *sbi = actiondfs_sbi(dir->i_sb);
 	struct actiondfs_node *parent = dir->i_private;
 	struct inode *inode = NULL;
 	int err;
@@ -2516,7 +2510,13 @@ static struct dentry *actiondfs_lookup(struct inode *dir,
 		return ERR_PTR(err);
 
 	actiondfs_stat_inc(ACTIONDFS_STAT_LOOKUPS);
-	inode = actiondfs_lookup_staged_inode(dir, dentry, parent);
+	if (sbi->stage_path.dentry) {
+		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUPS);
+		if (READ_ONCE(parent->stage_dentry))
+			inode = actiondfs_lookup_staged_inode(dir, dentry, parent);
+		else
+			actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_UNSTAGED_PARENT);
+	}
 	if (IS_ERR(inode))
 		return ERR_CAST(inode);
 	if (inode) {

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1019,29 +1019,19 @@ static bool actiondfs_retry_stale(int err, unsigned int *attempts)
 	return true;
 }
 
-static bool actiondfs_retry_open_stale(int err, unsigned int *attempts)
+#if ACTIONDFS_ENABLE_STATS
+static bool actiondfs_retry_counted_stale(int err, unsigned int *attempts,
+					 enum actiondfs_stat stat)
 {
 	if (!actiondfs_retry_stale(err, attempts))
 		return false;
-	actiondfs_stat_inc(ACTIONDFS_STAT_BLOB_OPEN_STALE_RETRIES);
+	actiondfs_stat_inc(stat);
 	return true;
 }
-
-static bool actiondfs_retry_backing_read_stale(int err, unsigned int *attempts)
-{
-	if (!actiondfs_retry_stale(err, attempts))
-		return false;
-	actiondfs_stat_inc(ACTIONDFS_STAT_BACKING_READ_STALE_RETRIES);
-	return true;
-}
-
-static bool actiondfs_retry_splice_read_stale(int err, unsigned int *attempts)
-{
-	if (!actiondfs_retry_stale(err, attempts))
-		return false;
-	actiondfs_stat_inc(ACTIONDFS_STAT_SPLICE_READ_STALE_RETRIES);
-	return true;
-}
+#else
+#define actiondfs_retry_counted_stale(err, attempts, stat) \
+	actiondfs_retry_stale((err), (attempts))
+#endif
 
 static struct file *actiondfs_open_directory_blob(struct actiondfs_sb_info *sbi,
 						 const char *hash)
@@ -1080,7 +1070,9 @@ static struct file *actiondfs_open_directory_blob(struct actiondfs_sb_info *sbi,
 		}
 
 		err = PTR_ERR(file);
-		if (!actiondfs_retry_open_stale(err, &stale_attempts))
+		if (!actiondfs_retry_counted_stale(
+			    err, &stale_attempts,
+			    ACTIONDFS_STAT_BLOB_OPEN_STALE_RETRIES))
 			return file;
 	}
 }
@@ -1134,7 +1126,9 @@ static struct file *actiondfs_open_backing_cas_blob(struct actiondfs_sb_info *sb
 		if (err == -ESTALE)
 			actiondfs_drop_cached_blob_path(sbi, hash);
 retry:
-		if (!actiondfs_retry_open_stale(err, &stale_attempts))
+		if (!actiondfs_retry_counted_stale(
+			    err, &stale_attempts,
+			    ACTIONDFS_STAT_BLOB_OPEN_STALE_RETRIES))
 			break;
 	}
 	actiondfs_stat_add_elapsed(ACTIONDFS_STAT_BLOB_OPEN_BACKING_TOTAL_NS,
@@ -1293,7 +1287,9 @@ static ssize_t actiondfs_read_iter(struct kiocb *iocb, struct iov_iter *to)
 				nread = err;
 		}
 		fput(file);
-	} while (actiondfs_retry_backing_read_stale(nread, &stale_attempts));
+	} while (actiondfs_retry_counted_stale(
+		nread, &stale_attempts,
+		ACTIONDFS_STAT_BACKING_READ_STALE_RETRIES));
 
 	if (nread > 0)
 		actiondfs_stat_add(ACTIONDFS_STAT_BACKING_READ_BYTES, (u64)nread);
@@ -1518,7 +1514,9 @@ static ssize_t actiondfs_splice_read(struct file *actiondfs_file, loff_t *ppos,
 				nread = err;
 		}
 		fput(file);
-	} while (actiondfs_retry_splice_read_stale(nread, &stale_attempts));
+	} while (actiondfs_retry_counted_stale(
+		nread, &stale_attempts,
+		ACTIONDFS_STAT_SPLICE_READ_STALE_RETRIES));
 
 	if (nread > 0) {
 		*ppos = pos;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -986,15 +986,17 @@ static int actiondfs_append_cached_symlink_child(struct actiondfs_cached_dir *pa
 					     target);
 }
 
-static int actiondfs_valid_hash(const char *hash)
+static int actiondfs_valid_hash(const char *hash, size_t len)
 {
 	size_t i;
 
+	if (len != ACTIONDFS_HASH_HEX_LEN)
+		return -EINVAL;
 	for (i = 0; i < ACTIONDFS_HASH_HEX_LEN; i++) {
 		if (hex_to_bin(hash[i]) < 0)
 			return -EINVAL;
 	}
-	return hash[ACTIONDFS_HASH_HEX_LEN] ? -EINVAL : 0;
+	return 0;
 }
 
 static bool actiondfs_is_empty_sha256(const char *hash)
@@ -1647,7 +1649,7 @@ static int actiondfs_pb_skip(const u8 *data, size_t len, size_t *pos, u64 wire)
 }
 
 struct actiondfs_reapi_digest {
-	char hash[ACTIONDFS_HASH_HEX_LEN + 1];
+	const char *hash;
 	u64 size;
 };
 
@@ -1670,7 +1672,7 @@ static int actiondfs_parse_reapi_digest(const u8 *data, size_t len,
 	size_t pos = 0;
 	int err;
 
-	digest->hash[0] = '\0';
+	digest->hash = NULL;
 	digest->size = 0;
 	while (pos < len) {
 		const u8 *field;
@@ -1689,12 +1691,10 @@ static int actiondfs_parse_reapi_digest(const u8 *data, size_t len,
 			err = actiondfs_pb_read_len(data, len, &pos, &field, &field_len);
 			if (err)
 				return err;
-			if (field_len != ACTIONDFS_HASH_HEX_LEN)
-				return -EINVAL;
-			actiondfs_copy_hash(digest->hash, field);
-			err = actiondfs_valid_hash(digest->hash);
+			err = actiondfs_valid_hash((const char *)field, field_len);
 			if (err)
 				return err;
+			digest->hash = (const char *)field;
 			break;
 		case 2:
 			if ((key & 7) != 0)
@@ -1713,7 +1713,7 @@ static int actiondfs_parse_reapi_digest(const u8 *data, size_t len,
 		}
 	}
 
-	return digest->hash[0] ? 0 : -EINVAL;
+	return digest->hash ? 0 : -EINVAL;
 }
 
 static int actiondfs_parse_reapi_child_fields(const u8 *data, size_t len,
@@ -1780,7 +1780,7 @@ static int actiondfs_parse_reapi_child_fields(const u8 *data, size_t len,
 		return -EINVAL;
 	if (S_ISLNK(mode))
 		return out->symlink.target ? 0 : -EINVAL;
-	return out->digest.hash[0] ? 0 : -EINVAL;
+	return out->digest.hash ? 0 : -EINVAL;
 }
 
 static int actiondfs_parse_reapi_cached_child(struct actiondfs_cached_dir *parent,
@@ -2236,7 +2236,7 @@ static int actiondfs_parse_options(struct actiondfs_mount_options *opts,
 
 	if (!opts->cas_root || !opts->root_hash)
 		return -EINVAL;
-	if (actiondfs_valid_hash(opts->root_hash))
+	if (actiondfs_valid_hash(opts->root_hash, strlen(opts->root_hash)))
 		return -EINVAL;
 	if (opts->root_size != ACTIONDFS_UNKNOWN_SIZE &&
 	    opts->root_size > ACTIONDFS_MAX_DIRECTORY_PROTO_SIZE)

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1900,11 +1900,9 @@ static int actiondfs_read_cas_blob(struct actiondfs_sb_info *sbi,
 
 static unsigned long actiondfs_digest_cache_key(const char *hash)
 {
-	unsigned long key = 0;
-	size_t i;
+	unsigned long key;
 
-	for (i = 0; i < 2 * sizeof(key); i++)
-		key = (key << 4) | hex_to_bin(hash[i]);
+	memcpy(&key, hash, sizeof(key));
 	return key;
 }
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1897,30 +1897,17 @@ static unsigned long actiondfs_digest_cache_key(const char *hash)
 }
 
 static struct actiondfs_blob_path_cache_entry *
-actiondfs_find_blob_path_cache_locked(struct actiondfs_sb_info *sbi,
-				      const char *hash)
+actiondfs_find_blob_path_cache(struct actiondfs_sb_info *sbi,
+			       const char *hash)
 {
 	struct actiondfs_blob_path_cache_entry *entry;
 	unsigned long key = actiondfs_digest_cache_key(hash);
 
-	hash_for_each_possible(actiondfs_blob_path_cache, entry, hnode, key) {
+	hash_for_each_possible_rcu(actiondfs_blob_path_cache, entry, hnode, key,
+				   lockdep_is_held(&actiondfs_blob_path_cache_lock)) {
 		if (entry->cas_root == sbi->cas_path.dentry &&
-		    !memcmp(entry->hash, hash, ACTIONDFS_HASH_HEX_LEN))
-			return entry;
-	}
-	return NULL;
-}
-
-static struct actiondfs_blob_path_cache_entry *
-actiondfs_find_blob_path_cache_rcu(struct actiondfs_sb_info *sbi,
-				   const char *hash)
-{
-	struct actiondfs_blob_path_cache_entry *entry;
-	unsigned long key = actiondfs_digest_cache_key(hash);
-
-	hash_for_each_possible_rcu(actiondfs_blob_path_cache, entry, hnode, key) {
-		if (entry->cas_root == sbi->cas_path.dentry &&
-		    !memcmp(entry->hash, hash, ACTIONDFS_HASH_HEX_LEN))
+		    (entry->hash == hash ||
+		     !memcmp(entry->hash, hash, ACTIONDFS_HASH_HEX_LEN)))
 			return entry;
 	}
 	return NULL;
@@ -1973,7 +1960,7 @@ static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 	entry->dentry = dget(path->dentry);
 
 	mutex_lock(&actiondfs_blob_path_cache_lock);
-	existing = actiondfs_find_blob_path_cache_locked(sbi, hash);
+	existing = actiondfs_find_blob_path_cache(sbi, hash);
 	if (existing) {
 		actiondfs_get_blob_path_cache_entry_locked(sbi, existing, out);
 		mutex_unlock(&actiondfs_blob_path_cache_lock);
@@ -2004,7 +1991,7 @@ static int actiondfs_get_cached_blob_path(struct actiondfs_sb_info *sbi,
 	int err;
 
 	rcu_read_lock();
-	entry = actiondfs_find_blob_path_cache_rcu(sbi, hash);
+	entry = actiondfs_find_blob_path_cache(sbi, hash);
 	if (entry) {
 		out->mnt = sbi->cas_path.mnt;
 		out->dentry = entry->dentry;
@@ -2034,7 +2021,7 @@ static void actiondfs_drop_cached_blob_path(struct actiondfs_sb_info *sbi,
 	struct actiondfs_blob_path_cache_entry *entry;
 
 	mutex_lock(&actiondfs_blob_path_cache_lock);
-	entry = actiondfs_find_blob_path_cache_locked(sbi, hash);
+	entry = actiondfs_find_blob_path_cache(sbi, hash);
 	if (entry)
 		actiondfs_unlink_blob_path_cache_entry_locked(entry);
 	mutex_unlock(&actiondfs_blob_path_cache_lock);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -69,7 +69,7 @@ struct actiondfs_cached_child {
 	u64 size;
 	u16 name_len;
 	umode_t mode;
-	char hash[ACTIONDFS_HASH_HEX_LEN + 1];
+	char hash[ACTIONDFS_HASH_HEX_LEN];
 };
 
 struct actiondfs_cached_children {
@@ -81,7 +81,7 @@ struct actiondfs_cached_children {
 struct actiondfs_cached_dir {
 	struct hlist_node hnode;
 	struct dentry *cas_root;
-	char hash[ACTIONDFS_HASH_HEX_LEN + 1];
+	char hash[ACTIONDFS_HASH_HEX_LEN];
 	u32 size;
 	struct actiondfs_cached_children files;
 	struct actiondfs_cached_children dirs;
@@ -125,7 +125,7 @@ struct actiondfs_sb_info {
 	struct path cas_path;
 	struct path stage_path;
 	struct actiondfs_node *root;
-	char root_hash[ACTIONDFS_HASH_HEX_LEN + 1];
+	char root_hash[ACTIONDFS_HASH_HEX_LEN];
 };
 
 struct actiondfs_mount_options {
@@ -413,12 +413,6 @@ static void actiondfs_drop_cached_blob_path(struct actiondfs_sb_info *sbi,
 static struct actiondfs_sb_info *actiondfs_sbi(struct super_block *sb)
 {
 	return sb->s_fs_info;
-}
-
-static void actiondfs_copy_hash(char *destination, const void *source)
-{
-	memcpy(destination, source, ACTIONDFS_HASH_HEX_LEN);
-	destination[ACTIONDFS_HASH_HEX_LEN] = '\0';
 }
 
 static void actiondfs_free_node(struct actiondfs_node *node)
@@ -965,7 +959,7 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_children *child
 	child->name_len = name_len;
 	child->mode = mode;
 	child->size = size;
-	actiondfs_copy_hash(child->hash, hash);
+	memcpy(child->hash, hash, ACTIONDFS_HASH_HEX_LEN);
 	children->count++;
 	return 0;
 }
@@ -2077,7 +2071,7 @@ static int actiondfs_build_cached_dir(struct actiondfs_sb_info *sbi,
 	if (!entry)
 		return -ENOMEM;
 	entry->cas_root = dget(sbi->cas_path.dentry);
-	actiondfs_copy_hash(entry->hash, hash);
+	memcpy(entry->hash, hash, ACTIONDFS_HASH_HEX_LEN);
 
 	err = actiondfs_read_cas_blob(sbi, hash, expected_size, &buffer, &len);
 	if (err)
@@ -3459,7 +3453,7 @@ static int actiondfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	} else {
 		sb->s_flags |= SB_RDONLY;
 	}
-	actiondfs_copy_hash(sbi->root_hash, opts.root_hash);
+	memcpy(sbi->root_hash, opts.root_hash, ACTIONDFS_HASH_HEX_LEN);
 	sbi->root->size = opts.root_size;
 
 	root_inode = actiondfs_iget(sb, sbi->root);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -620,8 +620,7 @@ static int actiondfs_ensure_stage_parent_path(struct actiondfs_sb_info *sbi,
 			goto out_error;
 		}
 		name_len = child->name_len;
-		if (!name_len || name_len > NAME_MAX ||
-		    name_len + 1 > PATH_MAX - path_len) {
+		if (name_len + 1 > PATH_MAX - path_len) {
 			err = -ENAMETOOLONG;
 			goto out_error;
 		}
@@ -1385,11 +1384,6 @@ static ssize_t actiondfs_copy_file_range(struct file *file_in, loff_t pos_in,
 
 	node_out = inode_out->i_private;
 	if (node_out->origin != ACTIONDFS_NODE_STAGED || node_in == node_out) {
-		copied = -EOPNOTSUPP;
-		goto out;
-	}
-	if (node_in->origin != ACTIONDFS_NODE_INPUT &&
-	    node_in->origin != ACTIONDFS_NODE_STAGED) {
 		copied = -EOPNOTSUPP;
 		goto out;
 	}
@@ -2197,8 +2191,6 @@ static int actiondfs_ensure_loaded(struct super_block *sb,
 	struct actiondfs_cached_dir *cached;
 	int err = 0;
 
-	if (!S_ISDIR(dir->mode))
-		return -ENOTDIR;
 	if (dir->origin == ACTIONDFS_NODE_STAGED ||
 	    smp_load_acquire(&dir->cached_dir))
 		return 0;
@@ -2770,9 +2762,6 @@ static int actiondfs_rmdir(struct inode *dir, struct dentry *dentry)
 		return -EROFS;
 	if (!S_ISDIR(node->mode))
 		return -ENOTDIR;
-	if (node->cached_dir)
-		return -EROFS;
-
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_RMDIR_CALLS);
 	err = actiondfs_remove_staged_child(dir, dentry, true);
 	actiondfs_stat_inc(err ? ACTIONDFS_STAT_STAGE_RMDIR_FAILURES :
@@ -2808,10 +2797,6 @@ static int actiondfs_rename(struct mnt_idmap *idmap, struct inode *old_dir,
 		return -EROFS;
 	if (new_node && new_node->origin != ACTIONDFS_NODE_STAGED)
 		return -EROFS;
-	if ((S_ISDIR(old_node->mode) && old_node->cached_dir) ||
-	    (new_node && S_ISDIR(new_node->mode) && new_node->cached_dir))
-		return -EROFS;
-
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_RENAME_CALLS);
 	err = actiondfs_stage_node_path(sbi, old_parent, &old_parent_path);
 	if (err)
@@ -3334,10 +3319,6 @@ static int actiondfs_dir_getattr(struct mnt_idmap *idmap,
 		return 0;
 	}
 
-	if (cached->dirs.count > UINT_MAX - 2) {
-		stat->nlink = 1;
-		return 0;
-	}
 	input_dir_count = cached->dirs.count;
 	if (!stage_dentry || backing_nlink == 2)
 		stat->nlink = 2 + input_dir_count;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -401,8 +401,6 @@ static const struct inode_operations actiondfs_file_iops;
 static const struct inode_operations actiondfs_symlink_iops;
 static const struct file_operations actiondfs_dir_fops;
 static const struct file_operations actiondfs_file_fops;
-static size_t actiondfs_readdir_start_index(loff_t ctx_pos, loff_t base,
-					    size_t count);
 static int actiondfs_get_cached_blob_path(struct actiondfs_sb_info *sbi,
 					  const char *hash,
 					  struct path *out);
@@ -3087,14 +3085,6 @@ static void actiondfs_reset_stage_file(struct actiondfs_dir_file *dir_file)
 	dir_file->stage_eof = false;
 }
 
-static void actiondfs_free_dir_file(struct actiondfs_dir_file *dir_file)
-{
-	if (!dir_file)
-		return;
-	actiondfs_reset_stage_file(dir_file);
-	kfree(dir_file);
-}
-
 static int actiondfs_open_stage_file(struct inode *inode,
 				    struct actiondfs_node *dir,
 				    struct actiondfs_dir_file *dir_file)
@@ -3196,7 +3186,10 @@ static int actiondfs_dir_open(struct inode *inode, struct file *file)
 
 static int actiondfs_dir_release(struct inode *inode, struct file *file)
 {
-	actiondfs_free_dir_file(file->private_data);
+	struct actiondfs_dir_file *dir_file = file->private_data;
+
+	actiondfs_reset_stage_file(dir_file);
+	kfree(dir_file);
 	file->private_data = NULL;
 	return 0;
 }
@@ -3206,8 +3199,15 @@ static bool actiondfs_emit_cached_children(
 	struct actiondfs_cached_children *children,
 	loff_t *base, unsigned int d_type)
 {
-	size_t index = actiondfs_readdir_start_index(ctx->pos, *base,
-						     children->count);
+	size_t index = 0;
+
+	if (ctx->pos > *base) {
+		index = min_t(u64, (u64)(ctx->pos - *base), children->count);
+		if (index)
+			actiondfs_stat_add(
+				ACTIONDFS_STAT_READDIR_SKIPPED_ENTRIES_AVOIDED,
+				(u64)index);
+	}
 
 	for (; index < children->count; index++) {
 		struct actiondfs_cached_child *child = &children->entries[index];
@@ -3260,26 +3260,6 @@ static int actiondfs_iterate_shared(struct file *file, struct dir_context *ctx)
 	}
 
 	return actiondfs_emit_stage_entries(inode, dir, dir_file, ctx, base);
-}
-
-static size_t actiondfs_readdir_start_index(loff_t ctx_pos, loff_t base,
-					    size_t count)
-{
-	loff_t delta;
-	size_t start;
-
-	if (ctx_pos <= base)
-		return 0;
-	delta = ctx_pos - base;
-	if (delta >= (loff_t)count)
-		start = count;
-	else
-		start = (size_t)delta;
-
-	if (start)
-		actiondfs_stat_add(ACTIONDFS_STAT_READDIR_SKIPPED_ENTRIES_AVOIDED,
-				   (u64)start);
-	return start;
 }
 
 static int actiondfs_dir_getattr(struct mnt_idmap *idmap,

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -12,6 +12,7 @@
 #include <linux/backing-file.h>
 #include <linux/atomic.h>
 #include <linux/cred.h>
+#include <linux/ctype.h>
 #include <linux/delay.h>
 #include <linux/delayed_call.h>
 #include <linux/err.h>
@@ -987,7 +988,7 @@ static int actiondfs_valid_hash(const char *hash, size_t len)
 	if (len != ACTIONDFS_HASH_HEX_LEN)
 		return -EINVAL;
 	for (i = 0; i < ACTIONDFS_HASH_HEX_LEN; i++) {
-		if (hex_to_bin(hash[i]) < 0)
+		if (!isxdigit(hash[i]))
 			return -EINVAL;
 	}
 	return 0;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -110,7 +110,6 @@ struct actiondfs_node {
 	u64 size;
 	enum actiondfs_node_origin origin;
 	umode_t mode;
-	const char *hash;
 	char *link_target;
 	const struct actiondfs_cached_child *input_child;
 	struct mutex load_lock;
@@ -770,7 +769,6 @@ actiondfs_materialize_cached_child(struct actiondfs_node *parent,
 					     record->name_len,
 					     S_ISDIR(record->mode));
 	node->size = record->size;
-	node->hash = record->hash;
 	if (S_ISLNK(record->mode))
 		node->link_target = record->name + record->name_len + 1;
 	return node;
@@ -1157,14 +1155,15 @@ static int actiondfs_reopen_node_blob_if_current(struct actiondfs_sb_info *sbi,
 						 struct file *actiondfs_file,
 						 struct file *current_file)
 {
+	const char *hash = node->input_child->hash;
 	struct file *replacement;
 	int err = 0;
 
 	mutex_lock(&node->load_lock);
 	if (actiondfs_file->private_data == current_file) {
-		actiondfs_drop_cached_blob_path(sbi, node->hash);
+		actiondfs_drop_cached_blob_path(sbi, hash);
 		replacement = actiondfs_open_backing_cas_blob(
-			sbi, node->hash, file_user_path(actiondfs_file), node->size);
+			sbi, hash, file_user_path(actiondfs_file), node->size);
 		if (IS_ERR(replacement)) {
 			err = PTR_ERR(replacement);
 		} else {
@@ -2081,7 +2080,7 @@ static int actiondfs_build_cached_dir(struct actiondfs_sb_info *sbi,
 	err = actiondfs_read_cas_blob(sbi, hash, expected_size, &buffer, &len);
 	if (err)
 		goto fail;
-	if (sbi->root && !memcmp(hash, sbi->root->hash, ACTIONDFS_HASH_HEX_LEN))
+	if (!memcmp(hash, sbi->root_hash, ACTIONDFS_HASH_HEX_LEN))
 		actiondfs_stat_inc(ACTIONDFS_STAT_ROOT_DIR_PARSES);
 	entry->size = len;
 	actiondfs_stat_inc(ACTIONDFS_STAT_CACHED_DIR_BUILDS);
@@ -2189,6 +2188,7 @@ static int actiondfs_ensure_loaded(struct super_block *sb,
 {
 	struct actiondfs_sb_info *sbi = actiondfs_sbi(sb);
 	struct actiondfs_cached_dir *cached;
+	const char *hash;
 	int err = 0;
 
 	if (dir->origin == ACTIONDFS_NODE_STAGED ||
@@ -2198,7 +2198,8 @@ static int actiondfs_ensure_loaded(struct super_block *sb,
 	mutex_lock(&dir->load_lock);
 	if (!smp_load_acquire(&dir->cached_dir)) {
 		actiondfs_stat_inc(ACTIONDFS_STAT_DIR_LOADS);
-		err = actiondfs_get_cached_dir(sbi, dir->hash, dir->size,
+		hash = dir->input_child ? dir->input_child->hash : sbi->root_hash;
+		err = actiondfs_get_cached_dir(sbi, hash, dir->size,
 						&cached);
 		if (!err)
 			smp_store_release(&dir->cached_dir, cached);
@@ -2902,11 +2903,13 @@ static int actiondfs_open(struct inode *inode, struct file *file)
 	    (file->f_mode & FMODE_WRITE))
 		return -EROFS;
 	if (node->origin == ACTIONDFS_NODE_INPUT) {
-		if (!node->size && actiondfs_is_empty_sha256(node->hash))
+		const char *hash = node->input_child->hash;
+
+		if (!node->size && actiondfs_is_empty_sha256(hash))
 			return 0;
 		actiondfs_stat_inc(ACTIONDFS_STAT_NODE_BLOB_CACHE_MISSES);
 		backing_file = actiondfs_open_backing_cas_blob(
-			sbi, node->hash, file_user_path(file), node->size);
+			sbi, hash, file_user_path(file), node->size);
 	} else {
 		backing_file = actiondfs_open_staged_backing(
 			sbi, file, actiondfs_staged_backing_flags(file));
@@ -3453,7 +3456,6 @@ static int actiondfs_fill_super(struct super_block *sb, struct fs_context *fc)
 		sb->s_flags |= SB_RDONLY;
 	}
 	actiondfs_copy_hash(sbi->root_hash, opts.root_hash);
-	sbi->root->hash = sbi->root_hash;
 	sbi->root->size = opts.root_size;
 
 	root_inode = actiondfs_iget(sb, sbi->root);


### PR DESCRIPTION
Simplify kernel/actiondfs/actiondfs.c in fifteen separately reviewable commits. Borrow immutable cached digests, reduce input inode and blob-cache allocations from kmalloc-192 to kmalloc-96, shrink parsed-child stack storage by 64 bytes, eliminate duplicate cache lookups and blob-path references, replace hexadecimal decoding with character classification, and avoid approximately 1.33 million unstaged-parent lookup calls in the LLVM workload. The actiondfs implementation removes 52 net lines.

Validation: complete supported ARM64/x86_64 Bazel build and test, standalone timing-parser test, production and instrumented macOS Virtualization.framework end-to-end tests, and a fresh LLVM VM smoke with 2,017 warmup plus 2,106 measured actions. The measured build completed in 136.185 seconds; local runs varied with host contention. Matched current-main GitHub Actions baselines are Linux 326.530/328.550 seconds (0.994x actiond/native) and Windows 365.645/376.549 seconds (0.971x), with 1,998 actions each.