### PR TITLE
actiondfs: simplify cached directories, inode ownership, and backing files

### DIFF
--- a/e2e/LLVM_VM_SMOKE_TIMINGS.md
+++ b/e2e/LLVM_VM_SMOKE_TIMINGS.md
@@ -27,21 +27,21 @@ subset of the VM `llvm-tblgen` graph.
 
 ## Latest Checked-In Result
 
-- Generated: `2026-08-01 08:31:36 EDT`
+- Generated: `2026-08-01 08:56:53 EDT`
 - Command: `ACTIOND_BAZEL_BUILD_FLAGS="--jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" ACTIOND_LLVM_SMOKE_MAC_HOST=0 e2e/run_llvm_vm_smoke.sh`
-- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.rAvy7K`
+- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.3d4ru5`
 - Workload: `@llvm-project//llvm:llvm-tblgen`, jobs=8
 - VM warmup target: `//e2e:llvm_exec_warmup`
 - Target and VM host platform: `@llvm//platforms:linux_arm64_musl`
 - Build mode: `-c opt --strip=always --stripopt=--strip-all`
-- VM warmup: `87.517s`; `2207 processes: 190 internal, 2017 remote`
-- Measured VM build: `103.064s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
+- VM warmup: `71.325s`; `2207 processes: 190 internal, 2017 remote`
+- Measured VM build: `74.995s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
 - Measured executions and timing records: `2106`
 - Mac-host baseline: not run (`ACTIOND_LLVM_SMOKE_MAC_HOST=0`)
 
 The previous checked-in run used the same jobs=8 and completed the warmup in
-`90.683s` and measured build in `135.518s`. The current measured build is 23.9%
-faster with the same 2,106 actions, while its warmup is 3.5% faster with the
+`87.517s` and measured build in `103.064s`. The current measured build is 27.2%
+faster with the same 2,106 actions, while its warmup is 18.5% faster with the
 same 2,017 actions. Intermediate runs on the same machine completed the
 warmup/measured builds in `96.032s`/`104.393s` and `94.614s`/`180.238s`. The
 large changes between identical action sets coincide with host CPU and memory
@@ -60,21 +60,21 @@ Counters include both warmup and measured builds.
 | Counter                              | Prior       | Current     |
 | ------------------------------------ | ----------: | ----------: |
 | actiondfs mounts                     |       4,122 |       4,122 |
-| root directory parses                |       1,405 |       1,406 |
-| cached directory hits                |     163,011 |     163,007 |
-| cached directory misses              |       6,606 |       6,610 |
-| directory blob reads                 |       6,605 |       6,609 |
-| staged ensure-directory calls        |      15,996 |      15,994 |
+| root directory parses                |       1,406 |       1,406 |
+| cached directory hits                |     163,007 |     163,007 |
+| cached directory misses              |       6,610 |       6,610 |
+| directory blob reads                 |       6,609 |       6,609 |
+| staged ensure-directory calls        |      15,994 |      15,994 |
 | staged ensure-directory components   |          16 |          16 |
 | staged ensure-directory existing     |           0 |           0 |
 | staged ensure-directory created      |          16 |          16 |
-| staged parent dentry hits            |      15,980 |      15,978 |
-| blob-path cache hits                 |     460,692 |     460,691 |
-| blob-path cache misses               |       6,883 |       6,884 |
+| staged parent dentry hits            |      15,978 |      15,978 |
+| blob-path cache hits                 |     460,691 |     460,691 |
+| blob-path cache misses               |       6,884 |       6,884 |
 | blob-path cache evictions            |           0 |           0 |
-| blob-path cache insertion races      |           0 |           1 |
-| staged backing open attempts         |      15,825 |      15,824 |
-| staged backing open lookup           | 0.767 ms    | 0.680 ms    |
+| blob-path cache insertion races      |           1 |           1 |
+| staged backing open attempts         |      15,824 |      15,824 |
+| staged backing open lookup           | 0.680 ms    | 0.632 ms    |
 | staged `copy_file_range` successes   |       3,828 |       3,828 |
 | staged `copy_file_range` fallbacks   |           0 |           0 |
 
@@ -82,7 +82,8 @@ The workload retained the same 2,017 warmup actions and 2,106 measured actions.
 All 163,007 cached-directory hits used RCU instead of the global directory-cache
 mutex, and all 18,382 staged input-directory merges searched only cached input
 directories. Root inode ownership reduced each of the 4,122 superblock
-allocations from 128 bytes to 96 bytes. Root-directory parsing, staged
+allocations from 128 bytes to 96 bytes, and unhashed root inodes avoided global
+inode-hash insertion on each mount. Root-directory parsing, staged
 parent-directory reuse, and blob-path cache behavior remain close to the previous
 checked-in result.
 
@@ -92,10 +93,10 @@ All timing values are milliseconds.
 
 | Stage                 |   Min |    p25 |    p50 |     p75 |      p95 |    Mean |       Max |
 | --------------------- | ----: | -----: | -----: | ------: | -------: | ------: | --------: |
-| total                 | 6.745 | 25.027 | 34.577 |  74.160 | 2024.802 | 337.545 | 10086.407 |
-| input fetch/setup     | 0.453 |  0.599 |  0.672 |   1.042 |    2.328 |   1.119 |    46.547 |
-| execute               | 6.143 | 23.013 | 32.741 |  70.832 | 2021.932 | 334.886 | 10079.382 |
-| output upload/collect | 0.020 |  0.145 |  0.287 |   1.790 |    5.823 |   1.539 |   126.589 |
+| total                 | 7.607 | 21.335 | 28.953 |  53.019 | 1380.981 | 241.158 |  6666.777 |
+| input fetch/setup     | 0.418 |  0.572 |  0.628 |   0.983 |    1.829 |   0.952 |    39.829 |
+| execute               | 5.237 | 19.657 | 27.051 |  50.836 | 1374.352 | 238.914 |  6642.901 |
+| output upload/collect | 0.020 |  0.129 |  0.256 |   1.469 |    4.519 |   1.292 |   201.862 |
 
 ## Runner Timing
 
@@ -105,12 +106,12 @@ and lazy actiondfs input reads. All timing values are milliseconds.
 
 | Runner Stage   |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | -------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| parent prepare | 0.058 |  0.099 |  0.123 |  0.158 |    0.465 |   0.203 |    12.161 |
-| fork           | 0.261 |  0.528 |  0.605 |  1.183 |    7.101 |   2.064 |   210.760 |
-| child setup    | 0.005 |  2.301 |  4.082 |  7.709 |   21.879 |   6.897 |   235.094 |
-| process/io     | 0.654 | 17.273 | 24.376 | 54.316 | 2012.426 | 325.008 | 10064.808 |
-| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    4.635 |   0.567 |    18.201 |
-| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.001 |     0.344 |
+| parent prepare | 0.058 |  0.092 |  0.116 |  0.155 |    0.292 |   0.196 |    33.258 |
+| fork           | 0.280 |  0.457 |  0.517 |  0.932 |    4.461 |   1.290 |    87.484 |
+| child setup    | 0.004 |  1.945 |  3.304 |  5.900 |   16.392 |   5.291 |   110.128 |
+| process/io     | 0.026 | 14.685 | 20.379 | 39.355 | 1367.614 | 231.656 |  6628.871 |
+| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    3.629 |   0.387 |    10.698 |
+| stdio digest   | 0.000 |  0.000 |  0.001 |  0.001 |    0.001 |   0.001 |     1.187 |
 
 ## actiondfs Counters
 
@@ -151,26 +152,26 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 | staged ensure-directory created      |          16 |
 | staged parent dentry hits            |      15,978 |
 | staged inode lookups                 |   1,406,667 |
-| staged inode unstaged-parent skips   |   1,331,308 |
+| staged inode unstaged-parent skips   |   1,331,309 |
 | staged inode lookup hits             |      35,518 |
-| staged inode lookup negative         |      39,841 |
+| staged inode lookup negative         |      39,840 |
 | staged inode input-directory merges  |      18,382 |
 | staged backing open attempts         |      15,824 |
 | staged backing open failures         |           0 |
-| staged backing open total            |   16.355 ms |
-| staged backing open lookup           |    0.680 ms |
-| staged backing open file             |   10.791 ms |
+| staged backing open total            |   11.208 ms |
+| staged backing open lookup           |    0.632 ms |
+| staged backing open file             |    8.477 ms |
 | staged create calls/successes        |      11,980 |
 | staged mkdir calls/successes         |         198 |
 | staged rename calls/successes        |       3,816 |
 | staged size updates/successes        |       3,874 |
-| staged write calls                   |      36,955 |
-| staged write bytes                   | 105,298,314 |
+| staged write calls                   |      36,940 |
+| staged write bytes                   | 105,205,576 |
 | staged `copy_file_range` successes   |       3,828 |
 | staged `copy_file_range` bytes       |  31,630,764 |
 | staged `copy_file_range` fallbacks   |           0 |
 
-The staged-negative filter skipped 1,331,308 lookups with known-unstaged
+The staged-negative filter skipped 1,331,309 lookups with known-unstaged
 parents. All 3,828 `copy_file_range` attempts succeeded without a buffered
 fallback.
 
@@ -182,10 +183,10 @@ fallback.
 | CAS promotion attempts               |      7,946 |
 | CAS promotion success                |      2,086 |
 | CAS existing-blob hits               |      5,860 |
-| CAS promoted bytes                   | 31,349,823 |
-| CAS digest bytes                     | 83,683,775 |
-| CAS promotion digest                 | 708.922 ms |
-| CAS promotion rename                 | 131.988 ms |
+| CAS promoted bytes                   | 31,257,287 |
+| CAS digest bytes                     | 83,591,239 |
+| CAS promotion digest                 | 672.445 ms |
+| CAS promotion rename                 | 105.677 ms |
 | CAS cross-device fallbacks           |          0 |
 | CAS permission fallbacks             |          0 |
 | CAS put-file copy calls              |          0 |
@@ -195,18 +196,18 @@ fallback.
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
 | ByteStream file reads                |      4,037 |
-| ByteStream file bytes                | 57,515,051 |
+| ByteStream file bytes                | 57,514,849 |
 | ByteStream buffered reads            |          0 |
 | gRPC response tasks started          |     36,228 |
 | gRPC response tasks failed           |          0 |
 | gRPC response concurrency waits      |          0 |
-| gRPC data frames                     |     37,004 |
-| gRPC file payload frames             |      6,896 |
-| gRPC `sendfile` attempts/successes   |      6,896 |
-| gRPC `sendfile` bytes                | 57,515,051 |
+| gRPC data frames                     |     37,003 |
+| gRPC file payload frames             |      6,895 |
+| gRPC `sendfile` attempts/successes   |      6,895 |
+| gRPC `sendfile` bytes                | 57,514,849 |
 | gRPC `sendfile` fallbacks            |          0 |
 
-The measured TCP-to-vsock bridge logged two connections, 28.34 MiB from client
-to guest, 37.37 MiB from guest to client, and zero read/write pump errors.
-ByteStream reads remained file-backed and all 6,896 gRPC `sendfile` attempts
+The measured TCP-to-vsock bridge logged two connections, 27.82 MiB from client
+to guest, 37.36 MiB from guest to client, and zero read/write pump errors.
+ByteStream reads remained file-backed and all 6,895 gRPC `sendfile` attempts
 succeeded.

--- a/e2e/LLVM_VM_SMOKE_TIMINGS.md
+++ b/e2e/LLVM_VM_SMOKE_TIMINGS.md
@@ -27,25 +27,27 @@ subset of the VM `llvm-tblgen` graph.
 
 ## Latest Checked-In Result
 
-- Generated: `2026-08-01 08:56:53 EDT`
+- Generated: `2026-08-01 11:00:07 EDT`
 - Command: `ACTIOND_BAZEL_BUILD_FLAGS="--jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" ACTIOND_LLVM_SMOKE_MAC_HOST=0 e2e/run_llvm_vm_smoke.sh`
-- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.3d4ru5`
+- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.Y0BFMG`
 - Workload: `@llvm-project//llvm:llvm-tblgen`, jobs=8
 - VM warmup target: `//e2e:llvm_exec_warmup`
 - Target and VM host platform: `@llvm//platforms:linux_arm64_musl`
 - Build mode: `-c opt --strip=always --stripopt=--strip-all`
-- VM warmup: `71.325s`; `2207 processes: 190 internal, 2017 remote`
-- Measured VM build: `74.995s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
+- VM warmup: `83.160s`; `2207 processes: 190 internal, 2017 remote`
+- Measured VM build: `88.494s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
 - Measured executions and timing records: `2106`
 - Mac-host baseline: not run (`ACTIOND_LLVM_SMOKE_MAC_HOST=0`)
 
 The previous checked-in run used the same jobs=8 and completed the warmup in
-`87.517s` and measured build in `103.064s`. The current measured build is 27.2%
-faster with the same 2,106 actions, while its warmup is 18.5% faster with the
-same 2,017 actions. Intermediate runs on the same machine completed the
-warmup/measured builds in `96.032s`/`104.393s` and `94.614s`/`180.238s`. The
-large changes between identical action sets coincide with host CPU and memory
-contention; compare matched CI actiond/native timings for performance changes.
+`71.325s` and measured build in `74.995s`. The current measured build is 18.0%
+slower with the same 2,106 actions, while its warmup is 16.6% slower with the
+same 2,017 actions. A repeat with the current code completed the warmup in
+`63.992s` and the measured build in `86.002s`. Intermediate runs on the same
+machine completed the warmup/measured builds in `96.032s`/`104.393s` and
+`94.614s`/`180.238s`. The large changes between identical action sets coincide
+with host CPU and memory contention; compare matched CI actiond/native timings
+for performance changes.
 
 Earlier checked-in runs completed the warmup and measured build in
 `102.136s`/`108.831s` and `106.289s`/`138.481s`. A run before action isolation
@@ -60,26 +62,26 @@ Counters include both warmup and measured builds.
 | Counter                              | Prior       | Current     |
 | ------------------------------------ | ----------: | ----------: |
 | actiondfs mounts                     |       4,122 |       4,122 |
-| root directory parses                |       1,406 |       1,406 |
-| cached directory hits                |     163,007 |     163,007 |
-| cached directory misses              |       6,610 |       6,610 |
-| directory blob reads                 |       6,609 |       6,609 |
-| staged ensure-directory calls        |      15,994 |      15,994 |
+| root directory parses                |       1,406 |       1,405 |
+| cached directory hits                |     163,007 |     163,011 |
+| cached directory misses              |       6,610 |       6,606 |
+| directory blob reads                 |       6,609 |       6,605 |
+| staged ensure-directory calls        |      15,994 |      15,996 |
 | staged ensure-directory components   |          16 |          16 |
 | staged ensure-directory existing     |           0 |           0 |
 | staged ensure-directory created      |          16 |          16 |
-| staged parent dentry hits            |      15,978 |      15,978 |
-| blob-path cache hits                 |     460,691 |     460,691 |
-| blob-path cache misses               |       6,884 |       6,884 |
+| staged parent dentry hits            |      15,978 |      15,980 |
+| blob-path cache hits                 |     460,691 |     460,692 |
+| blob-path cache misses               |       6,884 |       6,883 |
 | blob-path cache evictions            |           0 |           0 |
-| blob-path cache insertion races      |           1 |           1 |
-| staged backing open attempts         |      15,824 |      15,824 |
-| staged backing open lookup           | 0.680 ms    | 0.632 ms    |
+| blob-path cache insertion races      |           1 |           0 |
+| staged backing open attempts         |      15,824 |      15,825 |
+| staged backing open lookup           | 0.632 ms    | 0.705 ms    |
 | staged `copy_file_range` successes   |       3,828 |       3,828 |
 | staged `copy_file_range` fallbacks   |           0 |           0 |
 
 The workload retained the same 2,017 warmup actions and 2,106 measured actions.
-All 163,007 cached-directory hits used RCU instead of the global directory-cache
+All 163,011 cached-directory hits used RCU instead of the global directory-cache
 mutex, and all 18,382 staged input-directory merges searched only cached input
 directories. Root inode ownership reduced each of the 4,122 superblock
 allocations from 128 bytes to 96 bytes, and unhashed root inodes avoided global
@@ -93,10 +95,10 @@ All timing values are milliseconds.
 
 | Stage                 |   Min |    p25 |    p50 |     p75 |      p95 |    Mean |       Max |
 | --------------------- | ----: | -----: | -----: | ------: | -------: | ------: | --------: |
-| total                 | 7.607 | 21.335 | 28.953 |  53.019 | 1380.981 | 241.158 |  6666.777 |
-| input fetch/setup     | 0.418 |  0.572 |  0.628 |   0.983 |    1.829 |   0.952 |    39.829 |
-| execute               | 5.237 | 19.657 | 27.051 |  50.836 | 1374.352 | 238.914 |  6642.901 |
-| output upload/collect | 0.020 |  0.129 |  0.256 |   1.469 |    4.519 |   1.292 |   201.862 |
+| total                 | 6.403 | 24.241 | 32.814 |  79.441 | 1602.384 | 284.294 |  9398.972 |
+| input fetch/setup     | 0.410 |  0.579 |  0.654 |   1.028 |    2.046 |   1.128 |    63.747 |
+| execute               | 5.848 | 22.545 | 30.981 |  76.428 | 1599.830 | 281.827 |  9394.800 |
+| output upload/collect | 0.018 |  0.132 |  0.254 |   1.341 |    5.131 |   1.334 |    99.709 |
 
 ## Runner Timing
 
@@ -106,12 +108,12 @@ and lazy actiondfs input reads. All timing values are milliseconds.
 
 | Runner Stage   |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | -------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| parent prepare | 0.058 |  0.092 |  0.116 |  0.155 |    0.292 |   0.196 |    33.258 |
-| fork           | 0.280 |  0.457 |  0.517 |  0.932 |    4.461 |   1.290 |    87.484 |
-| child setup    | 0.004 |  1.945 |  3.304 |  5.900 |   16.392 |   5.291 |   110.128 |
-| process/io     | 0.026 | 14.685 | 20.379 | 39.355 | 1367.614 | 231.656 |  6628.871 |
-| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    3.629 |   0.387 |    10.698 |
-| stdio digest   | 0.000 |  0.000 |  0.001 |  0.001 |    0.001 |   0.001 |     1.187 |
+| parent prepare | 0.058 |  0.099 |  0.126 |  0.189 |    0.362 |   0.210 |    13.622 |
+| fork           | 0.465 |  0.711 |  0.817 |  1.962 |    7.877 |   2.598 |   104.185 |
+| child setup    | 0.005 |  2.828 |  4.616 |  7.882 |   24.387 |   7.945 |   120.755 |
+| process/io     | 1.593 | 15.476 | 22.015 | 54.143 | 1593.757 | 270.322 |  9391.259 |
+| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    4.385 |   0.575 |    58.915 |
+| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.001 |     0.959 |
 
 ## actiondfs Counters
 
@@ -120,18 +122,18 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 | Counter                       |           Value |
 | ----------------------------- | --------------: |
 | mounts                        |           4,122 |
-| root directory parses         |           1,406 |
+| root directory parses         |           1,405 |
 | cached directory requests     |         169,617 |
-| cached directory hits         |         163,007 |
-| cached directory misses       |           6,610 |
-| lookups                       |       1,406,667 |
+| cached directory hits         |         163,011 |
+| cached directory misses       |           6,606 |
+| lookups                       |       1,406,668 |
 | lookup hits                   |         841,778 |
-| lookup negative               |         564,889 |
-| blob open attempts            |         474,184 |
-| blob-path cache hits          |         460,691 |
-| blob-path cache misses        |           6,884 |
+| lookup negative               |         564,890 |
+| blob open attempts            |         474,180 |
+| blob-path cache hits          |         460,692 |
+| blob-path cache misses        |           6,883 |
 | blob-path cache evictions     |               0 |
-| blob-path cache insertion races |             1 |
+| blob-path cache insertion races |             0 |
 | node blob cache hits          |         472,190 |
 | node blob cache misses        |         467,575 |
 | backing reads                 |         415,332 |
@@ -139,39 +141,39 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 | mmap calls                    |          53,030 |
 | mmap bytes                    | 1,900,832,624,640 |
 | mmap failures                 |               0 |
-| directory blob reads          |           6,609 |
-| directory blob bytes          |       2,720,441 |
+| directory blob reads          |           6,605 |
+| directory blob bytes          |       2,720,060 |
 
 ## Staged Filesystem Counters
 
 | Counter                              |       Value |
 | ------------------------------------ | ----------: |
-| staged ensure-directory calls        |      15,994 |
+| staged ensure-directory calls        |      15,996 |
 | staged ensure-directory components   |          16 |
 | staged ensure-directory existing     |           0 |
 | staged ensure-directory created      |          16 |
-| staged parent dentry hits            |      15,978 |
-| staged inode lookups                 |   1,406,667 |
-| staged inode unstaged-parent skips   |   1,331,309 |
+| staged parent dentry hits            |      15,980 |
+| staged inode lookups                 |   1,406,668 |
+| staged inode unstaged-parent skips   |   1,331,308 |
 | staged inode lookup hits             |      35,518 |
-| staged inode lookup negative         |      39,840 |
+| staged inode lookup negative         |      39,842 |
 | staged inode input-directory merges  |      18,382 |
-| staged backing open attempts         |      15,824 |
+| staged backing open attempts         |      15,825 |
 | staged backing open failures         |           0 |
-| staged backing open total            |   11.208 ms |
-| staged backing open lookup           |    0.632 ms |
-| staged backing open file             |    8.477 ms |
-| staged create calls/successes        |      11,980 |
+| staged backing open total            |   12.397 ms |
+| staged backing open lookup           |    0.705 ms |
+| staged backing open file             |    8.407 ms |
+| staged create calls/successes        |      11,981 |
 | staged mkdir calls/successes         |         198 |
-| staged rename calls/successes        |       3,816 |
+| staged rename calls/successes        |       3,817 |
 | staged size updates/successes        |       3,874 |
-| staged write calls                   |      36,940 |
-| staged write bytes                   | 105,205,576 |
+| staged write calls                   |      37,149 |
+| staged write bytes                   | 106,183,143 |
 | staged `copy_file_range` successes   |       3,828 |
 | staged `copy_file_range` bytes       |  31,630,764 |
 | staged `copy_file_range` fallbacks   |           0 |
 
-The staged-negative filter skipped 1,331,309 lookups with known-unstaged
+The staged-negative filter skipped 1,331,308 lookups with known-unstaged
 parents. All 3,828 `copy_file_range` attempts succeeded without a buffered
 fallback.
 
@@ -179,14 +181,14 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| CAS put-file calls                   |      7,946 |
-| CAS promotion attempts               |      7,946 |
-| CAS promotion success                |      2,086 |
+| CAS put-file calls                   |      7,947 |
+| CAS promotion attempts               |      7,947 |
+| CAS promotion success                |      2,087 |
 | CAS existing-blob hits               |      5,860 |
-| CAS promoted bytes                   | 31,257,287 |
-| CAS digest bytes                     | 83,591,239 |
-| CAS promotion digest                 | 672.445 ms |
-| CAS promotion rename                 | 105.677 ms |
+| CAS promoted bytes                   | 32,132,663 |
+| CAS digest bytes                     | 84,466,615 |
+| CAS promotion digest                 | 712.061 ms |
+| CAS promotion rename                 | 103.887 ms |
 | CAS cross-device fallbacks           |          0 |
 | CAS permission fallbacks             |          0 |
 | CAS put-file copy calls              |          0 |
@@ -195,19 +197,19 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| ByteStream file reads                |      4,037 |
-| ByteStream file bytes                | 57,514,849 |
+| ByteStream file reads                |      4,038 |
+| ByteStream file bytes                | 57,617,030 |
 | ByteStream buffered reads            |          0 |
-| gRPC response tasks started          |     36,228 |
+| gRPC response tasks started          |     36,229 |
 | gRPC response tasks failed           |          0 |
 | gRPC response concurrency waits      |          0 |
-| gRPC data frames                     |     37,003 |
-| gRPC file payload frames             |      6,895 |
-| gRPC `sendfile` attempts/successes   |      6,895 |
-| gRPC `sendfile` bytes                | 57,514,849 |
+| gRPC data frames                     |     37,011 |
+| gRPC file payload frames             |      6,902 |
+| gRPC `sendfile` attempts/successes   |      6,902 |
+| gRPC `sendfile` bytes                | 57,617,030 |
 | gRPC `sendfile` fallbacks            |          0 |
 
-The measured TCP-to-vsock bridge logged two connections, 27.82 MiB from client
-to guest, 37.36 MiB from guest to client, and zero read/write pump errors.
-ByteStream reads remained file-backed and all 6,895 gRPC `sendfile` attempts
+The measured TCP-to-vsock bridge logged two connections, 28.09 MiB from client
+to guest, 37.37 MiB from guest to client, and zero read/write pump errors.
+ByteStream reads remained file-backed and all 6,902 gRPC `sendfile` attempts
 succeeded.

--- a/e2e/LLVM_VM_SMOKE_TIMINGS.md
+++ b/e2e/LLVM_VM_SMOKE_TIMINGS.md
@@ -27,21 +27,21 @@ subset of the VM `llvm-tblgen` graph.
 
 ## Latest Checked-In Result
 
-- Generated: `2026-08-01 00:33:32 EDT`
+- Generated: `2026-08-01 08:06:31 EDT`
 - Command: `ACTIOND_BAZEL_BUILD_FLAGS="--jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" ACTIOND_LLVM_SMOKE_MAC_HOST=0 e2e/run_llvm_vm_smoke.sh`
-- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.4zlbWj`
+- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.E2dFjW`
 - Workload: `@llvm-project//llvm:llvm-tblgen`, jobs=8
 - VM warmup target: `//e2e:llvm_exec_warmup`
 - Target and VM host platform: `@llvm//platforms:linux_arm64_musl`
 - Build mode: `-c opt --strip=always --stripopt=--strip-all`
-- VM warmup: `154.225s`; `2207 processes: 190 internal, 2017 remote`
-- Measured VM build: `136.185s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
+- VM warmup: `90.683s`; `2207 processes: 190 internal, 2017 remote`
+- Measured VM build: `135.518s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
 - Measured executions and timing records: `2106`
 - Mac-host baseline: not run (`ACTIOND_LLVM_SMOKE_MAC_HOST=0`)
 
 The previous checked-in run used the same jobs=8 and completed the warmup in
-`97.329s` and measured build in `147.209s`. The current measured build is 7.5%
-faster with the same 2,106 actions, while its warmup is 58.5% slower with the
+`154.225s` and measured build in `136.185s`. The current measured build is 0.5%
+faster with the same 2,106 actions, while its warmup is 41.2% faster with the
 same 2,017 actions. Intermediate runs on the same machine completed the
 warmup/measured builds in `96.032s`/`104.393s` and `94.614s`/`180.238s`. The
 large changes between identical action sets coincide with host CPU and memory
@@ -59,28 +59,30 @@ Counters include both warmup and measured builds.
 
 | Counter                              | Prior       | Current     |
 | ------------------------------------ | ----------: | ----------: |
-| actiondfs mounts                     |       4,122 |       4,123 |
-| root directory parses                |       1,406 |       1,406 |
-| cached directory hits                |     163,007 |     163,041 |
-| cached directory misses              |       6,610 |       6,624 |
-| directory blob reads                 |       6,609 |       6,623 |
-| staged ensure-directory calls        |      15,994 |      16,001 |
+| actiondfs mounts                     |       4,123 |       4,122 |
+| root directory parses                |       1,406 |       1,405 |
+| cached directory hits                |     163,041 |     163,011 |
+| cached directory misses              |       6,624 |       6,606 |
+| directory blob reads                 |       6,623 |       6,605 |
+| staged ensure-directory calls        |      16,001 |      15,996 |
 | staged ensure-directory components   |          16 |          16 |
 | staged ensure-directory existing     |           0 |           0 |
 | staged ensure-directory created      |          16 |          16 |
-| staged parent dentry hits            |      15,978 |      15,985 |
-| blob-path cache hits                 |     460,692 |     460,969 |
-| blob-path cache misses               |       6,883 |       6,971 |
+| staged parent dentry hits            |      15,985 |      15,980 |
+| blob-path cache hits                 |     460,969 |     460,692 |
+| blob-path cache misses               |       6,971 |       6,883 |
 | blob-path cache evictions            |           0 |           0 |
-| blob-path cache insertion races      |           0 |           1 |
-| staged backing open attempts         |      15,824 |      15,828 |
-| staged backing open lookup           | 0.648 ms    | 0.692 ms    |
+| blob-path cache insertion races      |           1 |           0 |
+| staged backing open attempts         |      15,828 |      15,825 |
+| staged backing open lookup           | 0.692 ms    | 0.767 ms    |
 | staged `copy_file_range` successes   |       3,828 |       3,828 |
 | staged `copy_file_range` fallbacks   |           0 |           0 |
 
 The workload retained the same 2,017 warmup actions and 2,106 measured actions.
-Root-directory parsing, directory blob reads, staged parent-directory reuse, and
-blob-path cache behavior remain close to the previous checked-in result.
+All 163,011 cached-directory hits used RCU instead of the global directory-cache
+mutex, and all 18,382 staged input-directory merges searched only cached input
+directories. Root-directory parsing, staged parent-directory reuse, and blob-path
+cache behavior remain close to the previous checked-in result.
 
 ## VM Stage Timing
 
@@ -88,10 +90,10 @@ All timing values are milliseconds.
 
 | Stage                 |   Min |    p25 |    p50 |     p75 |      p95 |    Mean |       Max |
 | --------------------- | ----: | -----: | -----: | ------: | -------: | ------: | --------: |
-| total                 | 7.856 | 30.071 | 51.388 | 190.619 | 2488.708 | 437.578 | 11479.179 |
-| input fetch/setup     | 0.415 |  0.594 |  0.845 |   1.234 |    4.437 |   1.740 |   188.989 |
-| execute               | 7.088 | 28.012 | 48.725 | 183.730 | 2478.244 | 433.987 | 11469.574 |
-| output upload/collect | 0.020 |  0.145 |  0.294 |   1.587 |    6.432 |   1.851 |   161.902 |
+| total                 | 8.021 | 26.410 | 38.320 | 116.137 | 2238.789 | 452.148 | 24442.519 |
+| input fetch/setup     | 0.432 |  0.585 |  0.675 |   1.127 |    3.094 |   1.461 |   105.492 |
+| execute               | 6.925 | 24.549 | 36.053 | 112.944 | 2217.573 | 449.112 | 24437.973 |
+| output upload/collect | 0.020 |  0.131 |  0.270 |   1.437 |    5.190 |   1.574 |    87.850 |
 
 ## Runner Timing
 
@@ -101,12 +103,12 @@ and lazy actiondfs input reads. All timing values are milliseconds.
 
 | Runner Stage   |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | -------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| parent prepare | 0.056 |  0.102 |  0.132 |  0.214 |    0.632 |   0.423 |    96.043 |
-| fork           | 0.331 |  0.561 |  0.752 |  1.843 |   19.644 |   5.298 |   408.534 |
-| child setup    | 0.006 |  3.421 |  6.095 | 14.244 |   56.363 |  14.388 |   287.535 |
-| process/io     | 2.457 | 19.980 | 32.946 | 121.092 | 2467.317 | 413.121 | 11440.529 |
-| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    4.235 |   0.538 |    43.349 |
-| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.006 |     8.539 |
+| parent prepare | 0.058 |  0.100 |  0.128 |  0.176 |    0.530 |   0.288 |    37.478 |
+| fork           | 0.311 |  0.509 |  0.581 |  1.390 |    7.693 |   2.771 |   258.063 |
+| child setup    | 0.004 |  2.902 |  5.029 |  9.908 |   42.663 |  11.278 |   263.507 |
+| process/io     | 0.812 | 17.610 | 25.679 | 83.382 | 2202.030 | 434.211 | 24435.404 |
+| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    2.999 |   0.304 |    15.723 |
+| stdio digest   | 0.000 |  0.000 |  0.001 |  0.001 |    0.001 |   0.001 |     0.105 |
 
 ## actiondfs Counters
 
@@ -114,59 +116,59 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 
 | Counter                       |           Value |
 | ----------------------------- | --------------: |
-| mounts                        |           4,123 |
-| root directory parses         |           1,406 |
-| cached directory requests     |         169,665 |
-| cached directory hits         |         163,041 |
-| cached directory misses       |           6,624 |
-| lookups                       |       1,407,099 |
-| lookup hits                   |         842,187 |
-| lookup negative               |         564,912 |
-| blob open attempts            |         474,563 |
-| blob-path cache hits          |         460,969 |
-| blob-path cache misses        |           6,971 |
+| mounts                        |           4,122 |
+| root directory parses         |           1,405 |
+| cached directory requests     |         169,617 |
+| cached directory hits         |         163,011 |
+| cached directory misses       |           6,606 |
+| lookups                       |       1,406,668 |
+| lookup hits                   |         841,778 |
+| lookup negative               |         564,890 |
+| blob open attempts            |         474,180 |
+| blob-path cache hits          |         460,692 |
+| blob-path cache misses        |           6,883 |
 | blob-path cache evictions     |               0 |
-| blob-path cache insertion races |             1 |
-| node blob cache hits          |         472,567 |
-| node blob cache misses        |         467,940 |
-| backing reads                 |         415,500 |
-| backing read bytes            |   1,303,975,362 |
-| mmap calls                    |          53,239 |
-| mmap bytes                    | 1,901,676,589,056 |
+| blob-path cache insertion races |             0 |
+| node blob cache hits          |         472,190 |
+| node blob cache misses        |         467,575 |
+| backing reads                 |         415,332 |
+| backing read bytes            |   1,303,012,282 |
+| mmap calls                    |          53,030 |
+| mmap bytes                    | 1,900,832,624,640 |
 | mmap failures                 |               0 |
-| directory blob reads          |           6,623 |
-| directory blob bytes          |       2,736,211 |
+| directory blob reads          |           6,605 |
+| directory blob bytes          |       2,720,060 |
 
 ## Staged Filesystem Counters
 
 | Counter                              |       Value |
 | ------------------------------------ | ----------: |
-| staged ensure-directory calls        |      16,001 |
+| staged ensure-directory calls        |      15,996 |
 | staged ensure-directory components   |          16 |
 | staged ensure-directory existing     |           0 |
 | staged ensure-directory created      |          16 |
-| staged parent dentry hits            |      15,985 |
-| staged inode lookups                 |   1,407,099 |
-| staged inode unstaged-parent skips   |   1,331,722 |
-| staged inode lookup hits             |      35,524 |
-| staged inode lookup negative         |      39,853 |
-| staged inode input-directory merges  |      18,388 |
-| staged backing open attempts         |      15,828 |
+| staged parent dentry hits            |      15,980 |
+| staged inode lookups                 |   1,406,668 |
+| staged inode unstaged-parent skips   |   1,331,308 |
+| staged inode lookup hits             |      35,518 |
+| staged inode lookup negative         |      39,842 |
+| staged inode input-directory merges  |      18,382 |
+| staged backing open attempts         |      15,825 |
 | staged backing open failures         |           0 |
-| staged backing open total            |   13.080 ms |
-| staged backing open lookup           |    0.692 ms |
-| staged backing open file             |    9.727 ms |
-| staged create calls/successes        |      11,984 |
+| staged backing open total            |   13.154 ms |
+| staged backing open lookup           |    0.767 ms |
+| staged backing open file             |    9.790 ms |
+| staged create calls/successes        |      11,981 |
 | staged mkdir calls/successes         |         198 |
-| staged rename calls/successes        |       3,819 |
-| staged size updates/successes        |       3,876 |
-| staged write calls                   |      37,194 |
-| staged write bytes                   | 106,356,427 |
+| staged rename calls/successes        |       3,817 |
+| staged size updates/successes        |       3,874 |
+| staged write calls                   |      37,077 |
+| staged write bytes                   | 105,822,678 |
 | staged `copy_file_range` successes   |       3,828 |
 | staged `copy_file_range` bytes       |  31,630,764 |
 | staged `copy_file_range` fallbacks   |           0 |
 
-The staged-negative filter skipped 1,331,722 lookups with known-unstaged
+The staged-negative filter skipped 1,331,308 lookups with known-unstaged
 parents. All 3,828 `copy_file_range` attempts succeeded without a buffered
 fallback.
 
@@ -174,14 +176,14 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| CAS put-file calls                   |      7,949 |
-| CAS promotion attempts               |      7,949 |
-| CAS promotion success                |      2,089 |
+| CAS put-file calls                   |      7,947 |
+| CAS promotion attempts               |      7,947 |
+| CAS promotion success                |      2,087 |
 | CAS existing-blob hits               |      5,860 |
-| CAS promoted bytes                   | 37,922,351 |
-| CAS digest bytes                     | 90,256,303 |
-| CAS promotion digest                 | 1,069.739 ms |
-| CAS promotion rename                 | 229.018 ms |
+| CAS promoted bytes                   | 31,772,519 |
+| CAS digest bytes                     | 84,106,471 |
+| CAS promotion digest                 | 734.725 ms |
+| CAS promotion rename                 | 264.452 ms |
 | CAS cross-device fallbacks           |          0 |
 | CAS permission fallbacks             |          0 |
 | CAS put-file copy calls              |          0 |
@@ -190,19 +192,19 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| ByteStream file reads                |      4,045 |
-| ByteStream file bytes                | 63,436,296 |
+| ByteStream file reads                |      4,038 |
+| ByteStream file bytes                | 57,616,709 |
 | ByteStream buffered reads            |          0 |
-| gRPC response tasks started          |     36,255 |
+| gRPC response tasks started          |     36,229 |
 | gRPC response tasks failed           |          0 |
 | gRPC response concurrency waits      |          0 |
-| gRPC data frames                     |     37,395 |
-| gRPC file payload frames             |      7,263 |
-| gRPC `sendfile` attempts/successes   |      7,263 |
-| gRPC `sendfile` bytes                | 63,436,296 |
+| gRPC data frames                     |     37,011 |
+| gRPC file payload frames             |      6,902 |
+| gRPC `sendfile` attempts/successes   |      6,902 |
+| gRPC `sendfile` bytes                | 57,616,709 |
 | gRPC `sendfile` fallbacks            |          0 |
 
-The measured TCP-to-vsock bridge logged two connections, 28.21 MiB from client
-to guest, 37.38 MiB from guest to client, and zero read/write pump errors.
-ByteStream reads remained file-backed and all 7,263 gRPC `sendfile` attempts
+The measured TCP-to-vsock bridge logged two connections, 28.04 MiB from client
+to guest, 37.37 MiB from guest to client, and zero read/write pump errors.
+ByteStream reads remained file-backed and all 6,902 gRPC `sendfile` attempts
 succeeded.

--- a/e2e/LLVM_VM_SMOKE_TIMINGS.md
+++ b/e2e/LLVM_VM_SMOKE_TIMINGS.md
@@ -27,21 +27,21 @@ subset of the VM `llvm-tblgen` graph.
 
 ## Latest Checked-In Result
 
-- Generated: `2026-08-01 08:06:31 EDT`
+- Generated: `2026-08-01 08:31:36 EDT`
 - Command: `ACTIOND_BAZEL_BUILD_FLAGS="--jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" ACTIOND_LLVM_SMOKE_MAC_HOST=0 e2e/run_llvm_vm_smoke.sh`
-- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.E2dFjW`
+- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.rAvy7K`
 - Workload: `@llvm-project//llvm:llvm-tblgen`, jobs=8
 - VM warmup target: `//e2e:llvm_exec_warmup`
 - Target and VM host platform: `@llvm//platforms:linux_arm64_musl`
 - Build mode: `-c opt --strip=always --stripopt=--strip-all`
-- VM warmup: `90.683s`; `2207 processes: 190 internal, 2017 remote`
-- Measured VM build: `135.518s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
+- VM warmup: `87.517s`; `2207 processes: 190 internal, 2017 remote`
+- Measured VM build: `103.064s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
 - Measured executions and timing records: `2106`
 - Mac-host baseline: not run (`ACTIOND_LLVM_SMOKE_MAC_HOST=0`)
 
 The previous checked-in run used the same jobs=8 and completed the warmup in
-`154.225s` and measured build in `136.185s`. The current measured build is 0.5%
-faster with the same 2,106 actions, while its warmup is 41.2% faster with the
+`90.683s` and measured build in `135.518s`. The current measured build is 23.9%
+faster with the same 2,106 actions, while its warmup is 3.5% faster with the
 same 2,017 actions. Intermediate runs on the same machine completed the
 warmup/measured builds in `96.032s`/`104.393s` and `94.614s`/`180.238s`. The
 large changes between identical action sets coincide with host CPU and memory
@@ -59,30 +59,32 @@ Counters include both warmup and measured builds.
 
 | Counter                              | Prior       | Current     |
 | ------------------------------------ | ----------: | ----------: |
-| actiondfs mounts                     |       4,123 |       4,122 |
-| root directory parses                |       1,406 |       1,405 |
-| cached directory hits                |     163,041 |     163,011 |
-| cached directory misses              |       6,624 |       6,606 |
-| directory blob reads                 |       6,623 |       6,605 |
-| staged ensure-directory calls        |      16,001 |      15,996 |
+| actiondfs mounts                     |       4,122 |       4,122 |
+| root directory parses                |       1,405 |       1,406 |
+| cached directory hits                |     163,011 |     163,007 |
+| cached directory misses              |       6,606 |       6,610 |
+| directory blob reads                 |       6,605 |       6,609 |
+| staged ensure-directory calls        |      15,996 |      15,994 |
 | staged ensure-directory components   |          16 |          16 |
 | staged ensure-directory existing     |           0 |           0 |
 | staged ensure-directory created      |          16 |          16 |
-| staged parent dentry hits            |      15,985 |      15,980 |
-| blob-path cache hits                 |     460,969 |     460,692 |
-| blob-path cache misses               |       6,971 |       6,883 |
+| staged parent dentry hits            |      15,980 |      15,978 |
+| blob-path cache hits                 |     460,692 |     460,691 |
+| blob-path cache misses               |       6,883 |       6,884 |
 | blob-path cache evictions            |           0 |           0 |
-| blob-path cache insertion races      |           1 |           0 |
-| staged backing open attempts         |      15,828 |      15,825 |
-| staged backing open lookup           | 0.692 ms    | 0.767 ms    |
+| blob-path cache insertion races      |           0 |           1 |
+| staged backing open attempts         |      15,825 |      15,824 |
+| staged backing open lookup           | 0.767 ms    | 0.680 ms    |
 | staged `copy_file_range` successes   |       3,828 |       3,828 |
 | staged `copy_file_range` fallbacks   |           0 |           0 |
 
 The workload retained the same 2,017 warmup actions and 2,106 measured actions.
-All 163,011 cached-directory hits used RCU instead of the global directory-cache
+All 163,007 cached-directory hits used RCU instead of the global directory-cache
 mutex, and all 18,382 staged input-directory merges searched only cached input
-directories. Root-directory parsing, staged parent-directory reuse, and blob-path
-cache behavior remain close to the previous checked-in result.
+directories. Root inode ownership reduced each of the 4,122 superblock
+allocations from 128 bytes to 96 bytes. Root-directory parsing, staged
+parent-directory reuse, and blob-path cache behavior remain close to the previous
+checked-in result.
 
 ## VM Stage Timing
 
@@ -90,10 +92,10 @@ All timing values are milliseconds.
 
 | Stage                 |   Min |    p25 |    p50 |     p75 |      p95 |    Mean |       Max |
 | --------------------- | ----: | -----: | -----: | ------: | -------: | ------: | --------: |
-| total                 | 8.021 | 26.410 | 38.320 | 116.137 | 2238.789 | 452.148 | 24442.519 |
-| input fetch/setup     | 0.432 |  0.585 |  0.675 |   1.127 |    3.094 |   1.461 |   105.492 |
-| execute               | 6.925 | 24.549 | 36.053 | 112.944 | 2217.573 | 449.112 | 24437.973 |
-| output upload/collect | 0.020 |  0.131 |  0.270 |   1.437 |    5.190 |   1.574 |    87.850 |
+| total                 | 6.745 | 25.027 | 34.577 |  74.160 | 2024.802 | 337.545 | 10086.407 |
+| input fetch/setup     | 0.453 |  0.599 |  0.672 |   1.042 |    2.328 |   1.119 |    46.547 |
+| execute               | 6.143 | 23.013 | 32.741 |  70.832 | 2021.932 | 334.886 | 10079.382 |
+| output upload/collect | 0.020 |  0.145 |  0.287 |   1.790 |    5.823 |   1.539 |   126.589 |
 
 ## Runner Timing
 
@@ -103,12 +105,12 @@ and lazy actiondfs input reads. All timing values are milliseconds.
 
 | Runner Stage   |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | -------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| parent prepare | 0.058 |  0.100 |  0.128 |  0.176 |    0.530 |   0.288 |    37.478 |
-| fork           | 0.311 |  0.509 |  0.581 |  1.390 |    7.693 |   2.771 |   258.063 |
-| child setup    | 0.004 |  2.902 |  5.029 |  9.908 |   42.663 |  11.278 |   263.507 |
-| process/io     | 0.812 | 17.610 | 25.679 | 83.382 | 2202.030 | 434.211 | 24435.404 |
-| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    2.999 |   0.304 |    15.723 |
-| stdio digest   | 0.000 |  0.000 |  0.001 |  0.001 |    0.001 |   0.001 |     0.105 |
+| parent prepare | 0.058 |  0.099 |  0.123 |  0.158 |    0.465 |   0.203 |    12.161 |
+| fork           | 0.261 |  0.528 |  0.605 |  1.183 |    7.101 |   2.064 |   210.760 |
+| child setup    | 0.005 |  2.301 |  4.082 |  7.709 |   21.879 |   6.897 |   235.094 |
+| process/io     | 0.654 | 17.273 | 24.376 | 54.316 | 2012.426 | 325.008 | 10064.808 |
+| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    4.635 |   0.567 |    18.201 |
+| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.001 |     0.344 |
 
 ## actiondfs Counters
 
@@ -117,18 +119,18 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 | Counter                       |           Value |
 | ----------------------------- | --------------: |
 | mounts                        |           4,122 |
-| root directory parses         |           1,405 |
+| root directory parses         |           1,406 |
 | cached directory requests     |         169,617 |
-| cached directory hits         |         163,011 |
-| cached directory misses       |           6,606 |
-| lookups                       |       1,406,668 |
+| cached directory hits         |         163,007 |
+| cached directory misses       |           6,610 |
+| lookups                       |       1,406,667 |
 | lookup hits                   |         841,778 |
-| lookup negative               |         564,890 |
-| blob open attempts            |         474,180 |
-| blob-path cache hits          |         460,692 |
-| blob-path cache misses        |           6,883 |
+| lookup negative               |         564,889 |
+| blob open attempts            |         474,184 |
+| blob-path cache hits          |         460,691 |
+| blob-path cache misses        |           6,884 |
 | blob-path cache evictions     |               0 |
-| blob-path cache insertion races |             0 |
+| blob-path cache insertion races |             1 |
 | node blob cache hits          |         472,190 |
 | node blob cache misses        |         467,575 |
 | backing reads                 |         415,332 |
@@ -136,34 +138,34 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 | mmap calls                    |          53,030 |
 | mmap bytes                    | 1,900,832,624,640 |
 | mmap failures                 |               0 |
-| directory blob reads          |           6,605 |
-| directory blob bytes          |       2,720,060 |
+| directory blob reads          |           6,609 |
+| directory blob bytes          |       2,720,441 |
 
 ## Staged Filesystem Counters
 
 | Counter                              |       Value |
 | ------------------------------------ | ----------: |
-| staged ensure-directory calls        |      15,996 |
+| staged ensure-directory calls        |      15,994 |
 | staged ensure-directory components   |          16 |
 | staged ensure-directory existing     |           0 |
 | staged ensure-directory created      |          16 |
-| staged parent dentry hits            |      15,980 |
-| staged inode lookups                 |   1,406,668 |
+| staged parent dentry hits            |      15,978 |
+| staged inode lookups                 |   1,406,667 |
 | staged inode unstaged-parent skips   |   1,331,308 |
 | staged inode lookup hits             |      35,518 |
-| staged inode lookup negative         |      39,842 |
+| staged inode lookup negative         |      39,841 |
 | staged inode input-directory merges  |      18,382 |
-| staged backing open attempts         |      15,825 |
+| staged backing open attempts         |      15,824 |
 | staged backing open failures         |           0 |
-| staged backing open total            |   13.154 ms |
-| staged backing open lookup           |    0.767 ms |
-| staged backing open file             |    9.790 ms |
-| staged create calls/successes        |      11,981 |
+| staged backing open total            |   16.355 ms |
+| staged backing open lookup           |    0.680 ms |
+| staged backing open file             |   10.791 ms |
+| staged create calls/successes        |      11,980 |
 | staged mkdir calls/successes         |         198 |
-| staged rename calls/successes        |       3,817 |
+| staged rename calls/successes        |       3,816 |
 | staged size updates/successes        |       3,874 |
-| staged write calls                   |      37,077 |
-| staged write bytes                   | 105,822,678 |
+| staged write calls                   |      36,955 |
+| staged write bytes                   | 105,298,314 |
 | staged `copy_file_range` successes   |       3,828 |
 | staged `copy_file_range` bytes       |  31,630,764 |
 | staged `copy_file_range` fallbacks   |           0 |
@@ -176,14 +178,14 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| CAS put-file calls                   |      7,947 |
-| CAS promotion attempts               |      7,947 |
-| CAS promotion success                |      2,087 |
+| CAS put-file calls                   |      7,946 |
+| CAS promotion attempts               |      7,946 |
+| CAS promotion success                |      2,086 |
 | CAS existing-blob hits               |      5,860 |
-| CAS promoted bytes                   | 31,772,519 |
-| CAS digest bytes                     | 84,106,471 |
-| CAS promotion digest                 | 734.725 ms |
-| CAS promotion rename                 | 264.452 ms |
+| CAS promoted bytes                   | 31,349,823 |
+| CAS digest bytes                     | 83,683,775 |
+| CAS promotion digest                 | 708.922 ms |
+| CAS promotion rename                 | 131.988 ms |
 | CAS cross-device fallbacks           |          0 |
 | CAS permission fallbacks             |          0 |
 | CAS put-file copy calls              |          0 |
@@ -192,19 +194,19 @@ fallback.
 
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
-| ByteStream file reads                |      4,038 |
-| ByteStream file bytes                | 57,616,709 |
+| ByteStream file reads                |      4,037 |
+| ByteStream file bytes                | 57,515,051 |
 | ByteStream buffered reads            |          0 |
-| gRPC response tasks started          |     36,229 |
+| gRPC response tasks started          |     36,228 |
 | gRPC response tasks failed           |          0 |
 | gRPC response concurrency waits      |          0 |
-| gRPC data frames                     |     37,011 |
-| gRPC file payload frames             |      6,902 |
-| gRPC `sendfile` attempts/successes   |      6,902 |
-| gRPC `sendfile` bytes                | 57,616,709 |
+| gRPC data frames                     |     37,004 |
+| gRPC file payload frames             |      6,896 |
+| gRPC `sendfile` attempts/successes   |      6,896 |
+| gRPC `sendfile` bytes                | 57,515,051 |
 | gRPC `sendfile` fallbacks            |          0 |
 
-The measured TCP-to-vsock bridge logged two connections, 28.04 MiB from client
+The measured TCP-to-vsock bridge logged two connections, 28.34 MiB from client
 to guest, 37.37 MiB from guest to client, and zero read/write pump errors.
-ByteStream reads remained file-backed and all 6,902 gRPC `sendfile` attempts
+ByteStream reads remained file-backed and all 6,896 gRPC `sendfile` attempts
 succeeded.

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1401,19 +1401,14 @@ static ssize_t actiondfs_copy_file_range(struct file *file_in, loff_t pos_in,
 	}
 
 	real_out = file_out->private_data;
-	if (!real_out)
-		real_out = ERR_PTR(-EBADF);
-	else
-		get_file(real_out);
-	if (IS_ERR(real_out)) {
-		copied = PTR_ERR(real_out);
+	if (!real_out) {
+		copied = -EBADF;
 		goto out_put_in;
 	}
 
 	copied = vfs_copy_file_range(real_in, pos_in, real_out, pos_out, len, 0);
 	if (copied > 0)
 		actiondfs_sync_staged_inode(inode_out, file_inode(real_out));
-	fput(real_out);
 out_put_in:
 	fput(real_in);
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -441,18 +441,17 @@ static struct actiondfs_node *actiondfs_alloc_node(umode_t mode)
 }
 
 static u64 actiondfs_input_child_ino(struct actiondfs_node *parent,
-				     const char *name, size_t name_len,
-				     bool is_dir)
+				     const struct actiondfs_cached_child *child)
 {
 	u64 hash = 1469598103934665603ULL;
 	size_t i;
 
 	hash ^= parent->ino;
 	hash *= 1099511628211ULL;
-	hash ^= is_dir ? 'd' : 'f';
+	hash ^= S_ISDIR(child->mode) ? 'd' : 'f';
 	hash *= 1099511628211ULL;
-	for (i = 0; i < name_len; i++) {
-		hash ^= (u8)name[i];
+	for (i = 0; i < child->name_len; i++) {
+		hash ^= (u8)child->name[i];
 		hash *= 1099511628211ULL;
 	}
 
@@ -762,9 +761,7 @@ actiondfs_materialize_cached_child(struct actiondfs_node *parent,
 
 	node->parent = parent;
 	node->input_child = record;
-	node->ino = actiondfs_input_child_ino(parent, record->name,
-					     record->name_len,
-					     S_ISDIR(record->mode));
+	node->ino = actiondfs_input_child_ino(parent, record);
 	node->size = record->size;
 	if (S_ISLNK(record->mode))
 		node->link_target = record->name + record->name_len + 1;
@@ -3203,10 +3200,7 @@ static bool actiondfs_emit_cached_children(
 		struct actiondfs_cached_child *child = &children->entries[index];
 
 		if (!dir_emit(ctx, child->name, child->name_len,
-			      actiondfs_input_child_ino(dir, child->name,
-						       child->name_len,
-						       d_type == DT_DIR),
-			      d_type))
+			      actiondfs_input_child_ino(dir, child), d_type))
 			return false;
 		actiondfs_stat_inc(ACTIONDFS_STAT_READDIR_ENTRIES);
 		ctx->pos = *base + index + 1;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -857,7 +857,6 @@ static void actiondfs_destroy_dir_cache(void)
 static void actiondfs_free_blob_path_cache_entry(struct actiondfs_blob_path_cache_entry *entry)
 {
 	dput(entry->dentry);
-	dput(entry->cas_root);
 	kfree(entry);
 }
 
@@ -1952,7 +1951,7 @@ static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 	}
 
 	entry->hash = hash;
-	entry->cas_root = dget(sbi->cas_path.dentry);
+	entry->cas_root = sbi->cas_path.dentry;
 	entry->dentry = dget(path->dentry);
 
 	mutex_lock(&actiondfs_blob_path_cache_lock);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -623,7 +623,7 @@ static int actiondfs_ensure_stage_parent_path(struct actiondfs_sb_info *sbi,
 		ancestor_node = ancestor_node->parent;
 	}
 
-	ancestors = kcalloc(depth, sizeof(*ancestors), GFP_KERNEL);
+	ancestors = kmalloc_array(depth, sizeof(*ancestors), GFP_KERNEL);
 	if (!ancestors) {
 		err = -ENOMEM;
 		goto out_error;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2020,13 +2020,14 @@ static void actiondfs_drop_cached_blob_path(struct actiondfs_sb_info *sbi,
 }
 
 static struct actiondfs_cached_dir *
-actiondfs_find_cached_dir_locked(struct actiondfs_sb_info *sbi,
-				 const char *hash)
+actiondfs_find_cached_dir(struct actiondfs_sb_info *sbi,
+			  const char *hash)
 {
 	struct actiondfs_cached_dir *entry;
 	unsigned long key = actiondfs_digest_cache_key(hash);
 
-	hash_for_each_possible(actiondfs_dir_cache, entry, hnode, key) {
+	hash_for_each_possible_rcu(actiondfs_dir_cache, entry, hnode, key,
+				   lockdep_is_held(&actiondfs_dir_cache_lock)) {
 		if (entry->cas_root == sbi->cas_path.dentry &&
 		    !memcmp(entry->hash, hash, ACTIONDFS_HASH_HEX_LEN))
 			return entry;
@@ -2120,9 +2121,9 @@ static int actiondfs_get_cached_dir(struct actiondfs_sb_info *sbi,
 	int err;
 
 	actiondfs_stat_inc(ACTIONDFS_STAT_CACHED_DIR_REQUESTS);
-	mutex_lock(&actiondfs_dir_cache_lock);
-	entry = actiondfs_find_cached_dir_locked(sbi, hash);
-	mutex_unlock(&actiondfs_dir_cache_lock);
+	rcu_read_lock();
+	entry = actiondfs_find_cached_dir(sbi, hash);
+	rcu_read_unlock();
 	if (entry) {
 		if (expected_size != ACTIONDFS_UNKNOWN_SIZE &&
 		    entry->size != expected_size)
@@ -2139,7 +2140,7 @@ static int actiondfs_get_cached_dir(struct actiondfs_sb_info *sbi,
 
 	key = actiondfs_digest_cache_key(hash);
 	mutex_lock(&actiondfs_dir_cache_lock);
-	existing = actiondfs_find_cached_dir_locked(sbi, hash);
+	existing = actiondfs_find_cached_dir(sbi, hash);
 	if (existing) {
 		mutex_unlock(&actiondfs_dir_cache_lock);
 		actiondfs_free_cached_dir(entry);
@@ -2150,7 +2151,7 @@ static int actiondfs_get_cached_dir(struct actiondfs_sb_info *sbi,
 		*out = existing;
 		return 0;
 	}
-	hash_add(actiondfs_dir_cache, &entry->hnode, key);
+	hash_add_rcu(actiondfs_dir_cache, &entry->hnode, key);
 	mutex_unlock(&actiondfs_dir_cache_lock);
 
 	*out = entry;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -3141,7 +3141,8 @@ static int actiondfs_dir_release(struct inode *inode, struct file *file)
 {
 	struct actiondfs_dir_file *dir_file = file->private_data;
 
-	actiondfs_reset_stage_file(dir_file);
+	if (dir_file->stage_file)
+		fput(dir_file->stage_file);
 	kfree(dir_file);
 	return 0;
 }

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1041,13 +1041,8 @@ static struct file *actiondfs_open_directory_blob(struct actiondfs_sb_info *sbi,
 					   current_cred());
 			path_put(&real_path);
 		}
-		if (!IS_ERR(file)) {
-			if (!S_ISREG(file_inode(file)->i_mode)) {
-				fput(file);
-				return ERR_PTR(-EIO);
-			}
+		if (!IS_ERR(file))
 			return file;
-		}
 
 		err = PTR_ERR(file);
 		if (!actiondfs_retry_counted_stale(

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -957,7 +957,8 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_children *child
 	child->name_len = name_len;
 	child->mode = mode;
 	child->size = size;
-	memcpy(child->hash, hash, ACTIONDFS_HASH_HEX_LEN);
+	if (!target)
+		memcpy(child->hash, hash, ACTIONDFS_HASH_HEX_LEN);
 	children->count++;
 	return 0;
 }
@@ -1769,7 +1770,7 @@ static int actiondfs_parse_reapi_cached_child(struct actiondfs_cached_dir *paren
 		return actiondfs_append_cached_child(
 			&parent->symlinks, child.name, child.name_len,
 			S_IFLNK | 0777, child.symlink.target_len,
-			ACTIONDFS_EMPTY_SHA256, child.symlink.target);
+			NULL, child.symlink.target);
 
 	if (S_ISREG(mode)) {
 		children = &parent->files;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -3395,7 +3395,7 @@ static int actiondfs_fill_super(struct super_block *sb, struct fs_context *fc)
 				&sbi->stage_path);
 		if (err)
 			goto fail;
-		actiondfs_set_stage_dentry(root, sbi->stage_path.dentry);
+		root->stage_dentry = dget(sbi->stage_path.dentry);
 	} else {
 		sb->s_flags |= SB_RDONLY;
 	}

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2849,12 +2849,11 @@ static int actiondfs_open(struct inode *inode, struct file *file)
 	struct actiondfs_sb_info *sbi = actiondfs_sbi(inode->i_sb);
 	struct file *backing_file;
 
-	if (node->origin != ACTIONDFS_NODE_STAGED &&
-	    (file->f_mode & FMODE_WRITE))
-		return -EROFS;
 	if (node->origin == ACTIONDFS_NODE_INPUT) {
 		const char *hash = node->input_child->hash;
 
+		if (file->f_mode & FMODE_WRITE)
+			return -EROFS;
 		if (!node->size && actiondfs_is_empty_sha256(hash))
 			return 0;
 		actiondfs_stat_inc(ACTIONDFS_STAT_NODE_BLOB_CACHE_MISSES);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2877,7 +2877,6 @@ static int actiondfs_release(struct inode *inode, struct file *file)
 	if (!backing_file)
 		return 0;
 	fput(backing_file);
-	file->private_data = NULL;
 	return 0;
 }
 
@@ -3145,7 +3144,6 @@ static int actiondfs_dir_release(struct inode *inode, struct file *file)
 
 	actiondfs_reset_stage_file(dir_file);
 	kfree(dir_file);
-	file->private_data = NULL;
 	return 0;
 }
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -920,6 +920,8 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_children *child
 	u32 capacity;
 	int err;
 
+	if (target && (!size || size >= PATH_MAX || memchr(target, '\0', size)))
+		return -EINVAL;
 	err = actiondfs_valid_component(name, name_len);
 	if (err)
 		return err;
@@ -959,22 +961,6 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_children *child
 	memcpy(child->hash, hash, ACTIONDFS_HASH_HEX_LEN);
 	children->count++;
 	return 0;
-}
-
-static int actiondfs_append_cached_symlink_child(struct actiondfs_cached_dir *parent,
-						 const char *name,
-						 size_t name_len,
-						 const char *target,
-						 size_t target_len)
-{
-	if (!target_len || target_len >= PATH_MAX ||
-	    memchr(target, '\0', target_len))
-		return -EINVAL;
-
-	return actiondfs_append_cached_child(&parent->symlinks,
-					     name, name_len, S_IFLNK | 0777,
-					     target_len, ACTIONDFS_EMPTY_SHA256,
-					     target);
 }
 
 static int actiondfs_valid_hash(const char *hash, size_t len)
@@ -1781,9 +1767,10 @@ static int actiondfs_parse_reapi_cached_child(struct actiondfs_cached_dir *paren
 	if (err)
 		return err;
 	if (S_ISLNK(mode))
-		return actiondfs_append_cached_symlink_child(
-			parent, child.name, child.name_len, child.symlink.target,
-			child.symlink.target_len);
+		return actiondfs_append_cached_child(
+			&parent->symlinks, child.name, child.name_len,
+			S_IFLNK | 0777, child.symlink.target_len,
+			ACTIONDFS_EMPTY_SHA256, child.symlink.target);
 
 	if (S_ISREG(mode)) {
 		children = &parent->files;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2380,7 +2380,6 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	char *link_target = NULL;
 	umode_t mode;
 	u64 size = 0;
-	bool merged_input = false;
 	int err;
 
 	err = actiondfs_stage_node_path(sbi, parent, &parent_path);
@@ -2410,7 +2409,6 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 						 dentry->d_name.name,
 						 dentry->d_name.len);
 		if (input_child && S_ISDIR(input_child->mode)) {
-			merged_input = true;
 			err = actiondfs_get_cached_dir(sbi, input_child->hash,
 						       input_child->size,
 						       &input_cached);
@@ -2430,7 +2428,7 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 		goto out_negative;
 	}
 
-	if (merged_input) {
+	if (input_cached) {
 		node = actiondfs_materialize_cached_child(parent, input_child);
 		if (IS_ERR(node)) {
 			err = PTR_ERR(node);
@@ -2457,7 +2455,7 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 		goto out_error;
 	}
 	if (inode->i_private != node) {
-		if (!merged_input)
+		if (!input_cached)
 			actiondfs_free_node(node);
 		node = inode->i_private;
 	}
@@ -2471,7 +2469,7 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 out_unlock:
 	actiondfs_stage_unlock_child(&parent_path, real_dentry);
 	path_put(&parent_path);
-	if (inode && !IS_ERR(inode) && merged_input) {
+	if (inode && !IS_ERR(inode) && input_cached) {
 		smp_store_release(&node->cached_dir, input_cached);
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_INPUT_DIR_MERGES);
 	}

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2300,10 +2300,10 @@ static void actiondfs_insert_staged_inode(struct inode *inode,
 	node->ino = real_inode->i_ino & ~(1ULL << 63);
 	node->mode = (node->mode & S_IFMT) |
 		     (real_inode->i_mode & permission_mask);
+	node->stage_dentry = dget(real_dentry);
 	inode->i_ino = node->ino;
 	inode->i_mode = node->mode;
 	insert_inode_hash(inode);
-	actiondfs_set_stage_dentry(node, real_dentry);
 }
 
 static int actiondfs_read_stage_symlink(struct dentry *dentry, char **target,

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1645,7 +1645,6 @@ static int actiondfs_parse_reapi_digest(const u8 *data, size_t len,
 		const u8 *field;
 		size_t field_len;
 		u64 key;
-		u64 value;
 
 		err = actiondfs_pb_read_varint(data, len, &pos, &key);
 		if (err)
@@ -1666,12 +1665,11 @@ static int actiondfs_parse_reapi_digest(const u8 *data, size_t len,
 		case 2:
 			if ((key & 7) != 0)
 				return -EINVAL;
-			err = actiondfs_pb_read_varint(data, len, &pos, &value);
+			err = actiondfs_pb_read_varint(data, len, &pos, &digest->size);
 			if (err)
 				return err;
-			if (value > (u64)MAX_LFS_FILESIZE)
+			if (digest->size > (u64)MAX_LFS_FILESIZE)
 				return -EINVAL;
-			digest->size = value;
 			break;
 		default:
 			err = actiondfs_pb_skip(data, len, &pos, key & 7);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -125,7 +125,6 @@ struct actiondfs_node {
 struct actiondfs_sb_info {
 	struct path cas_path;
 	struct path stage_path;
-	struct actiondfs_node *root;
 	char root_hash[ACTIONDFS_HASH_HEX_LEN];
 };
 
@@ -3317,16 +3316,11 @@ static const struct file_operations actiondfs_dir_fops = {
 static void actiondfs_evict_inode(struct inode *inode)
 {
 	struct actiondfs_node *node = inode->i_private;
-	struct actiondfs_sb_info *sbi = actiondfs_sbi(inode->i_sb);
 
 	truncate_inode_pages_final(&inode->i_data);
 	clear_inode(inode);
 	if (!node)
 		return;
-	if (sbi && node == sbi->root) {
-		inode->i_private = NULL;
-		return;
-	}
 	if (node->stage_dentry) {
 		dput(node->stage_dentry);
 		node->stage_dentry = NULL;
@@ -3350,7 +3344,6 @@ static void actiondfs_put_super(struct super_block *sb)
 
 	if (!sbi)
 		return;
-	actiondfs_free_node(sbi->root);
 	if (sbi->cas_path.dentry)
 		path_put(&sbi->cas_path);
 	if (sbi->stage_path.dentry)
@@ -3372,6 +3365,7 @@ static int actiondfs_fill_super(struct super_block *sb, struct fs_context *fc)
 		.root_size = ACTIONDFS_UNKNOWN_SIZE,
 	};
 	struct actiondfs_sb_info *sbi;
+	struct actiondfs_node *root = NULL;
 	struct inode *root_inode;
 	int err;
 
@@ -3388,12 +3382,12 @@ static int actiondfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	sb->s_op = &actiondfs_super_ops;
 	sb->s_time_gran = 1;
 
-	sbi->root = actiondfs_alloc_node(S_IFDIR | ACTIONDFS_DIR_MODE);
-	if (!sbi->root) {
+	root = actiondfs_alloc_node(S_IFDIR | ACTIONDFS_DIR_MODE);
+	if (!root) {
 		err = -ENOMEM;
 		goto fail;
 	}
-	sbi->root->ino = 1;
+	root->ino = 1;
 
 	err = actiondfs_parse_options(&opts, fc->fs_private);
 	if (err)
@@ -3407,18 +3401,19 @@ static int actiondfs_fill_super(struct super_block *sb, struct fs_context *fc)
 				&sbi->stage_path);
 		if (err)
 			goto fail;
-		actiondfs_set_stage_dentry(sbi->root, sbi->stage_path.dentry);
+		actiondfs_set_stage_dentry(root, sbi->stage_path.dentry);
 	} else {
 		sb->s_flags |= SB_RDONLY;
 	}
 	memcpy(sbi->root_hash, opts.root_hash, ACTIONDFS_HASH_HEX_LEN);
-	sbi->root->size = opts.root_size;
+	root->size = opts.root_size;
 
-	root_inode = actiondfs_iget(sb, sbi->root);
+	root_inode = actiondfs_iget(sb, root);
 	if (IS_ERR(root_inode)) {
 		err = PTR_ERR(root_inode);
 		goto fail;
 	}
+	root = NULL;
 
 	sb->s_root = d_make_root(root_inode);
 	if (!sb->s_root) {
@@ -3429,6 +3424,7 @@ static int actiondfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	return 0;
 
 fail:
+	actiondfs_free_node(root);
 	actiondfs_put_super(sb);
 	return err;
 }

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -829,13 +829,10 @@ static void actiondfs_free_cached_children(
 
 static void actiondfs_free_cached_dir(struct actiondfs_cached_dir *dir)
 {
-	if (!dir)
-		return;
 	actiondfs_free_cached_children(&dir->files);
 	actiondfs_free_cached_children(&dir->dirs);
 	actiondfs_free_cached_children(&dir->symlinks);
-	if (dir->cas_root)
-		dput(dir->cas_root);
+	dput(dir->cas_root);
 	kfree(dir);
 }
 
@@ -2081,7 +2078,8 @@ static int actiondfs_build_cached_dir(struct actiondfs_sb_info *sbi,
 		goto out_buffer;
 
 	*out = entry;
-	entry = NULL;
+	kvfree(buffer);
+	return 0;
 
 out_buffer:
 	kvfree(buffer);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2399,10 +2399,11 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	mode = real_inode->i_mode;
 	if (S_ISDIR(mode)) {
 		mode = S_IFDIR | (mode & S_IALLUGO);
-		input_child = actiondfs_find_cached_child(parent,
-						 dentry->d_name.name,
-						 dentry->d_name.len);
-		if (input_child && S_ISDIR(input_child->mode)) {
+		if (parent->cached_dir)
+			input_child = actiondfs_find_cached_child_in(
+				&parent->cached_dir->dirs, dentry->d_name.name,
+				dentry->d_name.len);
+		if (input_child) {
 			err = actiondfs_get_cached_dir(sbi, input_child->hash,
 						       input_child->size,
 						       &input_cached);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2227,9 +2227,7 @@ static int actiondfs_test_input_inode(struct inode *inode, void *data)
 	struct actiondfs_node *candidate = data;
 	struct actiondfs_node *existing = inode->i_private;
 
-	return existing && existing->origin == ACTIONDFS_NODE_INPUT &&
-	       existing->ino == candidate->ino &&
-	       existing->parent == candidate->parent &&
+	return existing && existing->parent == candidate->parent &&
 	       existing->input_child == candidate->input_child;
 }
 
@@ -2271,7 +2269,7 @@ static struct inode *actiondfs_iget(struct super_block *sb,
 				    struct actiondfs_node *node)
 {
 	struct inode *inode;
-	bool input_child = node->origin == ACTIONDFS_NODE_INPUT && node->parent;
+	bool input_child = node->input_child != NULL;
 
 	if (input_child)
 		inode = iget5_locked(sb, node->ino, actiondfs_test_input_inode,

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -435,7 +435,6 @@ static struct actiondfs_node *actiondfs_alloc_node(umode_t mode)
 		return NULL;
 
 	node->mode = mode;
-	mutex_init(&node->load_lock);
 	return node;
 }
 
@@ -758,6 +757,8 @@ actiondfs_materialize_cached_child(struct actiondfs_node *parent,
 	if (!node)
 		return ERR_PTR(-ENOMEM);
 
+	if (!S_ISLNK(record->mode))
+		mutex_init(&node->load_lock);
 	node->parent = parent;
 	node->input_child = record;
 	node->ino = actiondfs_input_child_ino(parent, record);
@@ -3376,6 +3377,7 @@ static int actiondfs_fill_super(struct super_block *sb, struct fs_context *fc)
 		err = -ENOMEM;
 		goto fail;
 	}
+	mutex_init(&root->load_lock);
 	root->ino = 1;
 
 	err = actiondfs_parse_options(&opts, fc->fs_private);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -482,11 +482,11 @@ actiondfs_alloc_staged_node(struct actiondfs_node *parent,
 static void actiondfs_set_stage_dentry(struct actiondfs_node *node,
 				       struct dentry *dentry)
 {
-	struct dentry *old;
+	if (smp_load_acquire(&node->stage_dentry))
+		return;
 
 	dget(dentry);
-	old = cmpxchg(&node->stage_dentry, NULL, dentry);
-	if (old)
+	if (cmpxchg(&node->stage_dentry, NULL, dentry))
 		dput(dentry);
 }
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -3400,11 +3400,12 @@ static int actiondfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	memcpy(sbi->root_hash, opts.root_hash, ACTIONDFS_HASH_HEX_LEN);
 	root->size = opts.root_size;
 
-	root_inode = actiondfs_iget(sb, root);
-	if (IS_ERR(root_inode)) {
-		err = PTR_ERR(root_inode);
+	root_inode = new_inode(sb);
+	if (!root_inode) {
+		err = -ENOMEM;
 		goto fail;
 	}
+	actiondfs_init_inode(root_inode, root);
 	root = NULL;
 
 	sb->s_root = d_make_root(root_inode);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2932,7 +2932,7 @@ static int actiondfs_fsync(struct file *file, loff_t start, loff_t end,
 		backing_file = file->private_data;
 		if (!backing_file)
 			return -EBADF;
-		get_file(backing_file);
+		return vfs_fsync_range(backing_file, start, end, datasync);
 	}
 
 	err = vfs_fsync_range(backing_file, start, end, datasync);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2234,7 +2234,6 @@ static void actiondfs_init_inode(struct inode *inode,
 		inode->i_op = &actiondfs_symlink_iops;
 		inode_set_cached_link(inode, node->link_target, node->size);
 		i_size_write(inode, node->size);
-		set_nlink(inode, 1);
 	} else if (S_ISDIR(node->mode)) {
 		inode->i_op = &actiondfs_dir_iops;
 		inode->i_fop = &actiondfs_dir_fops;
@@ -2243,7 +2242,6 @@ static void actiondfs_init_inode(struct inode *inode,
 		inode->i_op = &actiondfs_file_iops;
 		inode->i_fop = &actiondfs_file_fops;
 		i_size_write(inode, node->size);
-		set_nlink(inode, 1);
 	}
 }
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1370,8 +1370,6 @@ static ssize_t actiondfs_copy_file_range(struct file *file_in, loff_t pos_in,
 		real_in = file_in->private_data;
 		if (!real_in)
 			real_in = ERR_PTR(-EBADF);
-		else
-			get_file(real_in);
 	}
 	if (IS_ERR(real_in)) {
 		copied = PTR_ERR(real_in);
@@ -1388,7 +1386,8 @@ static ssize_t actiondfs_copy_file_range(struct file *file_in, loff_t pos_in,
 	if (copied > 0)
 		actiondfs_sync_staged_inode(inode_out, file_inode(real_out));
 out_put_in:
-	fput(real_in);
+	if (node_in->origin == ACTIONDFS_NODE_INPUT)
+		fput(real_in);
 
 out:
 	if (copied >= 0) {


### PR DESCRIPTION
Continue #25 with 25 separately reviewable actiondfs cleanups. Derive inode and merged-directory state from cached children, use RCU for immutable directory-cache hits, search only cached input directories, borrow backing dentries and staged copy files, transfer root-node ownership to root inodes, reduce each superblock allocation from 128 to 96 bytes, allocate unhashed roots directly, publish staged backing dentries before inode insertion, initialize locks only for loadable inputs, and remove unnecessary ancestor zeroing, repeated inode classification, blob checks, synthetic symlink digests, protobuf copies, cache cleanup branches, and released-file state resets.

Validation: all 66 supported Bazel targets, both repository test suites, the standalone timing-parser test, production and instrumented Virtualization.framework VM end-to-end tests, and two fresh llvm-tblgen VM smoke runs with identical 2,106 remote actions (88.494s and 86.002s; previous run 74.995s). Warmups ranged from 63.992s to 83.160s, indicating host contention; compare matched Linux and Windows CI actiond/native results for performance changes. e2e/LLVM_VM_SMOKE_TIMINGS.md contains the exact counters and both measurements.