### PR TITLE
actiondfs: harden staged permissions and simplify backing paths

### DIFF
--- a/e2e/LLVM_VM_SMOKE_TIMINGS.md
+++ b/e2e/LLVM_VM_SMOKE_TIMINGS.md
@@ -27,22 +27,22 @@ subset of the VM `llvm-tblgen` graph.
 
 ## Latest Checked-In Result
 
-- Generated: `2026-08-01 11:00:07 EDT`
+- Generated: `2026-08-01 15:44:38 EDT`
 - Command: `ACTIOND_BAZEL_BUILD_FLAGS="--jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" ACTIOND_LLVM_SMOKE_MAC_HOST=0 e2e/run_llvm_vm_smoke.sh`
-- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.Y0BFMG`
+- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.yu77B2`
 - Workload: `@llvm-project//llvm:llvm-tblgen`, jobs=8
 - VM warmup target: `//e2e:llvm_exec_warmup`
 - Target and VM host platform: `@llvm//platforms:linux_arm64_musl`
 - Build mode: `-c opt --strip=always --stripopt=--strip-all`
-- VM warmup: `83.160s`; `2207 processes: 190 internal, 2017 remote`
-- Measured VM build: `88.494s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
+- VM warmup: `82.129s`; `2207 processes: 190 internal, 2017 remote`
+- Measured VM build: `92.336s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
 - Measured executions and timing records: `2106`
 - Mac-host baseline: not run (`ACTIOND_LLVM_SMOKE_MAC_HOST=0`)
 
 The previous checked-in run used the same jobs=8 and completed the warmup in
-`71.325s` and measured build in `74.995s`. The current measured build is 18.0%
-slower with the same 2,106 actions, while its warmup is 16.6% slower with the
-same 2,017 actions. A repeat with the current code completed the warmup in
+`83.160s` and measured build in `88.494s`. The current measured build is 4.3%
+slower with the same 2,106 actions, while its warmup is 1.2% faster with the
+same 2,017 actions. A repeat with the previous code completed the warmup in
 `63.992s` and the measured build in `86.002s`. Intermediate runs on the same
 machine completed the warmup/measured builds in `96.032s`/`104.393s` and
 `94.614s`/`180.238s`. The large changes between identical action sets coincide
@@ -62,30 +62,31 @@ Counters include both warmup and measured builds.
 | Counter                              | Prior       | Current     |
 | ------------------------------------ | ----------: | ----------: |
 | actiondfs mounts                     |       4,122 |       4,122 |
-| root directory parses                |       1,406 |       1,405 |
-| cached directory hits                |     163,007 |     163,011 |
-| cached directory misses              |       6,610 |       6,606 |
-| directory blob reads                 |       6,609 |       6,605 |
-| staged ensure-directory calls        |      15,994 |      15,996 |
+| root directory parses                |       1,405 |       1,405 |
+| cached directory hits                |     163,011 |     162,998 |
+| cached directory misses              |       6,606 |       6,619 |
+| directory blob reads                 |       6,605 |       6,618 |
+| staged ensure-directory calls        |      15,996 |      15,996 |
 | staged ensure-directory components   |          16 |          16 |
 | staged ensure-directory existing     |           0 |           0 |
 | staged ensure-directory created      |          16 |          16 |
-| staged parent dentry hits            |      15,978 |      15,980 |
-| blob-path cache hits                 |     460,691 |     460,692 |
-| blob-path cache misses               |       6,884 |       6,883 |
+| staged parent dentry hits            |      15,980 |      15,980 |
+| blob-path cache hits                 |     460,692 |     460,692 |
+| blob-path cache misses               |       6,883 |       6,883 |
 | blob-path cache evictions            |           0 |           0 |
-| blob-path cache insertion races      |           1 |           0 |
-| staged backing open attempts         |      15,824 |      15,825 |
-| staged backing open lookup           | 0.632 ms    | 0.705 ms    |
+| blob-path cache insertion races      |           0 |           0 |
+| staged backing open attempts         |      15,825 |      15,825 |
+| staged backing open lookup           | 0.705 ms    | 0.297 ms    |
 | staged `copy_file_range` successes   |       3,828 |       3,828 |
 | staged `copy_file_range` fallbacks   |           0 |           0 |
 
 The workload retained the same 2,017 warmup actions and 2,106 measured actions.
-All 163,011 cached-directory hits used RCU instead of the global directory-cache
+All 162,998 cached-directory hits used RCU instead of the global directory-cache
 mutex, and all 18,382 staged input-directory merges searched only cached input
 directories. Root inode ownership reduced each of the 4,122 superblock
 allocations from 128 bytes to 96 bytes, and unhashed root inodes avoided global
-inode-hash insertion on each mount. Root-directory parsing, staged
+inode-hash insertion on each mount. CAS blob lookups and staged parent lookups
+borrowed existing mount or path references. Root-directory parsing, staged
 parent-directory reuse, and blob-path cache behavior remain close to the previous
 checked-in result.
 
@@ -95,10 +96,10 @@ All timing values are milliseconds.
 
 | Stage                 |   Min |    p25 |    p50 |     p75 |      p95 |    Mean |       Max |
 | --------------------- | ----: | -----: | -----: | ------: | -------: | ------: | --------: |
-| total                 | 6.403 | 24.241 | 32.814 |  79.441 | 1602.384 | 284.294 |  9398.972 |
-| input fetch/setup     | 0.410 |  0.579 |  0.654 |   1.028 |    2.046 |   1.128 |    63.747 |
-| execute               | 5.848 | 22.545 | 30.981 |  76.428 | 1599.830 | 281.827 |  9394.800 |
-| output upload/collect | 0.018 |  0.132 |  0.254 |   1.341 |    5.131 |   1.334 |    99.709 |
+| total                 | 7.303 | 22.280 | 31.502 |  72.387 | 1654.434 | 304.721 |  9170.784 |
+| input fetch/setup     | 0.405 |  0.586 |  0.642 |   0.996 |    1.994 |   1.034 |    60.478 |
+| execute               | 5.979 | 20.755 | 29.458 |  71.567 | 1651.500 | 302.320 |  9161.111 |
+| output upload/collect | 0.022 |  0.138 |  0.262 |   1.601 |    5.233 |   1.367 |   157.599 |
 
 ## Runner Timing
 
@@ -108,12 +109,12 @@ and lazy actiondfs input reads. All timing values are milliseconds.
 
 | Runner Stage   |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | -------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| parent prepare | 0.058 |  0.099 |  0.126 |  0.189 |    0.362 |   0.210 |    13.622 |
-| fork           | 0.465 |  0.711 |  0.817 |  1.962 |    7.877 |   2.598 |   104.185 |
-| child setup    | 0.005 |  2.828 |  4.616 |  7.882 |   24.387 |   7.945 |   120.755 |
-| process/io     | 1.593 | 15.476 | 22.015 | 54.143 | 1593.757 | 270.322 |  9391.259 |
-| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    4.385 |   0.575 |    58.915 |
-| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.001 |     0.959 |
+| parent prepare | 0.049 |  0.100 |  0.124 |  0.154 |    0.395 |   0.193 |    12.384 |
+| fork           | 0.252 |  0.505 |  0.576 |  1.042 |    5.887 |   1.766 |   201.901 |
+| child setup    | 0.004 |  1.761 |  3.161 |  6.020 |   21.088 |   6.044 |   107.745 |
+| process/io     | 0.588 | 15.747 | 22.252 | 52.498 | 1646.214 | 293.593 |  9134.104 |
+| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    4.334 |   0.575 |    14.531 |
+| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.001 |     0.142 |
 
 ## actiondfs Counters
 
@@ -124,12 +125,12 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 | mounts                        |           4,122 |
 | root directory parses         |           1,405 |
 | cached directory requests     |         169,617 |
-| cached directory hits         |         163,011 |
-| cached directory misses       |           6,606 |
+| cached directory hits         |         162,998 |
+| cached directory misses       |           6,619 |
 | lookups                       |       1,406,668 |
 | lookup hits                   |         841,778 |
 | lookup negative               |         564,890 |
-| blob open attempts            |         474,180 |
+| blob open attempts            |         474,193 |
 | blob-path cache hits          |         460,692 |
 | blob-path cache misses        |           6,883 |
 | blob-path cache evictions     |               0 |
@@ -141,8 +142,8 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 | mmap calls                    |          53,030 |
 | mmap bytes                    | 1,900,832,624,640 |
 | mmap failures                 |               0 |
-| directory blob reads          |           6,605 |
-| directory blob bytes          |       2,720,060 |
+| directory blob reads          |           6,618 |
+| directory blob bytes          |       2,732,839 |
 
 ## Staged Filesystem Counters
 
@@ -160,15 +161,15 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 | staged inode input-directory merges  |      18,382 |
 | staged backing open attempts         |      15,825 |
 | staged backing open failures         |           0 |
-| staged backing open total            |   12.397 ms |
-| staged backing open lookup           |    0.705 ms |
-| staged backing open file             |    8.407 ms |
+| staged backing open total            |   12.784 ms |
+| staged backing open lookup           |    0.297 ms |
+| staged backing open file             |   10.582 ms |
 | staged create calls/successes        |      11,981 |
 | staged mkdir calls/successes         |         198 |
 | staged rename calls/successes        |       3,817 |
 | staged size updates/successes        |       3,874 |
-| staged write calls                   |      37,149 |
-| staged write bytes                   | 106,183,143 |
+| staged write calls                   |      37,140 |
+| staged write bytes                   | 106,132,435 |
 | staged `copy_file_range` successes   |       3,828 |
 | staged `copy_file_range` bytes       |  31,630,764 |
 | staged `copy_file_range` fallbacks   |           0 |
@@ -185,10 +186,10 @@ fallback.
 | CAS promotion attempts               |      7,947 |
 | CAS promotion success                |      2,087 |
 | CAS existing-blob hits               |      5,860 |
-| CAS promoted bytes                   | 32,132,663 |
-| CAS digest bytes                     | 84,466,615 |
-| CAS promotion digest                 | 712.061 ms |
-| CAS promotion rename                 | 103.887 ms |
+| CAS promoted bytes                   | 32,082,447 |
+| CAS digest bytes                     | 84,416,399 |
+| CAS promotion digest                 | 642.254 ms |
+| CAS promotion rename                 | 127.801 ms |
 | CAS cross-device fallbacks           |          0 |
 | CAS permission fallbacks             |          0 |
 | CAS put-file copy calls              |          0 |
@@ -198,7 +199,7 @@ fallback.
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
 | ByteStream file reads                |      4,038 |
-| ByteStream file bytes                | 57,617,030 |
+| ByteStream file bytes                | 57,616,538 |
 | ByteStream buffered reads            |          0 |
 | gRPC response tasks started          |     36,229 |
 | gRPC response tasks failed           |          0 |
@@ -206,10 +207,10 @@ fallback.
 | gRPC data frames                     |     37,011 |
 | gRPC file payload frames             |      6,902 |
 | gRPC `sendfile` attempts/successes   |      6,902 |
-| gRPC `sendfile` bytes                | 57,617,030 |
+| gRPC `sendfile` bytes                | 57,616,538 |
 | gRPC `sendfile` fallbacks            |          0 |
 
-The measured TCP-to-vsock bridge logged two connections, 28.09 MiB from client
-to guest, 37.37 MiB from guest to client, and zero read/write pump errors.
+The measured TCP-to-vsock bridge logged two connections, 28.25 MiB from client
+to guest, 37.36 MiB from guest to client, and zero read/write pump errors.
 ByteStream reads remained file-backed and all 6,902 gRPC `sendfile` attempts
 succeeded.

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -521,7 +521,8 @@ static int actiondfs_stage_lookup_child(struct path *parent_path,
 
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CHILD_LOOKUPS);
 	inode_lock_nested(parent_inode, I_MUTEX_PARENT);
-	dentry = lookup_one(&nop_mnt_idmap, &qname, parent_path->dentry);
+	dentry = lookup_one(mnt_idmap(parent_path->mnt), &qname,
+			    parent_path->dentry);
 	if (IS_ERR(dentry)) {
 		inode_unlock(parent_inode);
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CHILD_LOOKUP_ERRORS);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2939,7 +2939,6 @@ static int actiondfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 		setattr_copy(idmap, inode, attr);
 		if (attr->ia_valid & ATTR_MODE)
 			node->mode = inode->i_mode;
-		mark_inode_dirty(inode);
 	}
 
 out_drop_write:

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2712,13 +2712,15 @@ static int actiondfs_rename(struct mnt_idmap *idmap, struct inode *old_dir,
 		err = PTR_ERR(trap);
 		goto out_drop_write;
 	}
-	real_old = lookup_one(&nop_mnt_idmap, &old_name, old_parent_path.dentry);
+	real_old = lookup_one(mnt_idmap(old_parent_path.mnt), &old_name,
+			      old_parent_path.dentry);
 	if (IS_ERR(real_old)) {
 		err = PTR_ERR(real_old);
 		real_old = NULL;
 		goto out_unlock;
 	}
-	real_new = lookup_one(&nop_mnt_idmap, &new_name, new_parent_path.dentry);
+	real_new = lookup_one(mnt_idmap(new_parent_path.mnt), &new_name,
+			      new_parent_path.dentry);
 	if (IS_ERR(real_new)) {
 		err = PTR_ERR(real_new);
 		real_new = NULL;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2903,6 +2903,7 @@ static int actiondfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 		goto out;
 
 	real_attr = *attr;
+	real_attr.ia_valid &= ~ATTR_OPEN;
 	if (real_attr.ia_valid & (ATTR_KILL_SUID | ATTR_KILL_SGID))
 		real_attr.ia_valid &= ~ATTR_MODE;
 	if (real_attr.ia_valid & ATTR_FILE) {

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2862,6 +2862,7 @@ static int actiondfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 {
 	struct inode *inode = d_inode(dentry);
 	struct actiondfs_node *node = inode->i_private;
+	struct actiondfs_sb_info *sbi = actiondfs_sbi(inode->i_sb);
 	struct path real_path;
 	struct iattr real_attr;
 	bool changing_size = attr->ia_valid & ATTR_SIZE;
@@ -2875,15 +2876,19 @@ static int actiondfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 	err = setattr_prepare(idmap, dentry, attr);
 	if (err)
 		goto out;
-	err = actiondfs_stage_node_path(actiondfs_sbi(inode->i_sb), node,
-				       &real_path);
-	if (err)
-		goto out;
-	err = mnt_want_write(real_path.mnt);
-	if (err) {
-		path_put(&real_path);
+	if (!sbi->stage_path.dentry) {
+		err = -EROFS;
 		goto out;
 	}
+	real_path.mnt = sbi->stage_path.mnt;
+	real_path.dentry = READ_ONCE(node->stage_dentry);
+	if (!real_path.dentry) {
+		err = -ENOENT;
+		goto out;
+	}
+	err = mnt_want_write(real_path.mnt);
+	if (err)
+		goto out;
 
 	real_attr = *attr;
 	if (real_attr.ia_valid & ATTR_FILE) {
@@ -2910,7 +2915,6 @@ static int actiondfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 
 out_drop_write:
 	mnt_drop_write(real_path.mnt);
-	path_put(&real_path);
 out:
 	if (changing_size) {
 		if (err)

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -586,6 +586,7 @@ static int actiondfs_ensure_stage_parent_path(struct actiondfs_sb_info *sbi,
 {
 	struct actiondfs_node **ancestors;
 	struct actiondfs_node *ancestor_node;
+	struct dentry *stage_dentry;
 	struct path current_path;
 	size_t depth = 0;
 	size_t path_len = 0;
@@ -597,9 +598,12 @@ static int actiondfs_ensure_stage_parent_path(struct actiondfs_sb_info *sbi,
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_ENSURE_DIR_ERRORS);
 		return -EROFS;
 	}
-	if (smp_load_acquire(&node->stage_dentry)) {
+	stage_dentry = smp_load_acquire(&node->stage_dentry);
+	if (stage_dentry) {
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_PARENT_DENTRY_HITS);
-		return actiondfs_stage_node_path(sbi, node, path);
+		path->mnt = sbi->stage_path.mnt;
+		path->dentry = stage_dentry;
+		return 0;
 	}
 
 	ancestor_node = node;
@@ -681,7 +685,9 @@ static int actiondfs_ensure_stage_parent_path(struct actiondfs_sb_info *sbi,
 		current_path = next_path;
 	}
 
-	*path = current_path;
+	path->mnt = sbi->stage_path.mnt;
+	path->dentry = smp_load_acquire(&node->stage_dentry);
+	path_put(&current_path);
 	kfree(ancestors);
 	return 0;
 
@@ -2513,7 +2519,7 @@ static int actiondfs_create_staged_child(struct inode *dir,
 		goto out_put_inode;
 	err = mnt_want_write(parent_path.mnt);
 	if (err)
-		goto out_put_path;
+		goto out_put_inode;
 	err = actiondfs_stage_lookup_child(&parent_path, dentry->d_name.name,
 					   dentry->d_name.len, &real_dentry);
 	if (err)
@@ -2561,8 +2567,6 @@ static int actiondfs_create_staged_child(struct inode *dir,
 
 out_drop_write:
 	mnt_drop_write(parent_path.mnt);
-out_put_path:
-	path_put(&parent_path);
 out_put_inode:
 	iput(inode);
 	return err;
@@ -2731,7 +2735,7 @@ static int actiondfs_rename(struct mnt_idmap *idmap, struct inode *old_dir,
 		goto out_done;
 	err = mnt_want_write(old_parent_path.mnt);
 	if (err)
-		goto out_put_new_path;
+		goto out_done;
 
 	trap = lock_rename(new_parent_path.dentry, old_parent_path.dentry);
 	if (IS_ERR(trap)) {
@@ -2802,8 +2806,6 @@ out_unlock:
 	unlock_rename(new_parent_path.dentry, old_parent_path.dentry);
 out_drop_write:
 	mnt_drop_write(old_parent_path.mnt);
-out_put_new_path:
-	path_put(&new_parent_path);
 out_done:
 	if (err)
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_RENAME_FAILURES);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2255,11 +2255,10 @@ static void actiondfs_insert_staged_inode(struct inode *inode,
 {
 	struct actiondfs_node *node = inode->i_private;
 	struct inode *real_inode = d_inode(real_dentry);
-	umode_t permission_mask = S_ISDIR(node->mode) ? S_IALLUGO : 0777;
 
 	node->ino = real_inode->i_ino & ~(1ULL << 63);
 	node->mode = (node->mode & S_IFMT) |
-		     (real_inode->i_mode & permission_mask);
+		     (real_inode->i_mode & S_IALLUGO);
 	node->stage_dentry = dget(real_dentry);
 	inode->i_ino = node->ino;
 	inode->i_mode = node->mode;
@@ -2341,7 +2340,7 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 				goto out_error;
 		}
 	} else if (S_ISREG(mode)) {
-		mode = S_IFREG | (mode & 0777);
+		mode = S_IFREG | (mode & S_IALLUGO);
 		size = i_size_read(real_inode);
 	} else if (S_ISLNK(mode)) {
 		err = actiondfs_read_stage_symlink(real_dentry, &link_target,

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1210,7 +1210,6 @@ static ssize_t actiondfs_read_iter(struct kiocb *iocb, struct iov_iter *to)
 	unsigned int stale_attempts = 0;
 	struct backing_file_ctx ctx = {
 		.cred = current_cred(),
-		.accessed = file_accessed,
 	};
 
 	if (!requested)
@@ -1418,7 +1417,6 @@ static ssize_t actiondfs_splice_read(struct file *actiondfs_file, loff_t *ppos,
 	unsigned int stale_attempts = 0;
 	struct backing_file_ctx ctx = {
 		.cred = current_cred(),
-		.accessed = file_accessed,
 	};
 
 	if (node->origin == ACTIONDFS_NODE_STAGED) {
@@ -1498,7 +1496,6 @@ static int actiondfs_mmap(struct file *actiondfs_file,
 	int err;
 	struct backing_file_ctx ctx = {
 		.cred = current_cred(),
-		.accessed = file_accessed,
 	};
 
 	if (node->origin == ACTIONDFS_NODE_STAGED) {

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2287,7 +2287,8 @@ out:
 
 static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 						   struct dentry *dentry,
-						   struct actiondfs_node *parent)
+						   struct actiondfs_node *parent,
+						   struct dentry *stage_dentry)
 {
 	struct actiondfs_sb_info *sbi = actiondfs_sbi(dir->i_sb);
 	struct actiondfs_cached_child *input_child = NULL;
@@ -2303,11 +2304,7 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	int err;
 
 	parent_path.mnt = sbi->stage_path.mnt;
-	parent_path.dentry = READ_ONCE(parent->stage_dentry);
-	if (!parent_path.dentry) {
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_NEGATIVE);
-		return NULL;
-	}
+	parent_path.dentry = stage_dentry;
 	err = actiondfs_stage_lookup_child(&parent_path, dentry->d_name.name,
 					   dentry->d_name.len, &real_dentry);
 	if (err) {
@@ -2407,6 +2404,7 @@ static struct dentry *actiondfs_lookup(struct inode *dir,
 {
 	struct actiondfs_sb_info *sbi = actiondfs_sbi(dir->i_sb);
 	struct actiondfs_node *parent = dir->i_private;
+	struct dentry *stage_dentry;
 	struct inode *inode = NULL;
 	int err;
 
@@ -2418,12 +2416,14 @@ static struct dentry *actiondfs_lookup(struct inode *dir,
 		return ERR_PTR(err);
 
 	actiondfs_stat_inc(ACTIONDFS_STAT_LOOKUPS);
-	if (sbi->stage_path.dentry) {
+	stage_dentry = READ_ONCE(parent->stage_dentry);
+	if (stage_dentry) {
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUPS);
-		if (READ_ONCE(parent->stage_dentry))
-			inode = actiondfs_lookup_staged_inode(dir, dentry, parent);
-		else
-			actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_UNSTAGED_PARENT);
+		inode = actiondfs_lookup_staged_inode(dir, dentry, parent,
+						     stage_dentry);
+	} else if (sbi->stage_path.dentry) {
+		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUPS);
+		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_UNSTAGED_PARENT);
 	}
 	if (IS_ERR(inode))
 		return ERR_CAST(inode);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2531,7 +2531,7 @@ static int actiondfs_create_staged_child(struct inode *dir,
 	} else {
 		err = vfs_create(mnt_idmap(parent_path.mnt),
 				 d_inode(parent_path.dentry), real_dentry,
-				 mode & 0777, excl);
+				 mode & S_IALLUGO, excl);
 		inode_unlock(d_inode(parent_path.dentry));
 	}
 	if (err) {
@@ -2564,7 +2564,7 @@ static int actiondfs_create(struct mnt_idmap *idmap, struct inode *dir,
 		return -EROFS;
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CREATE_CALLS);
 	err = actiondfs_create_staged_child(dir, dentry,
-					   S_IFREG | (mode & 0777), NULL, excl);
+					   S_IFREG | (mode & S_IALLUGO), NULL, excl);
 	actiondfs_stat_inc(err ? ACTIONDFS_STAT_STAGE_CREATE_FAILURES :
 			  ACTIONDFS_STAT_STAGE_CREATE_SUCCESS);
 	return err;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -757,14 +757,14 @@ actiondfs_materialize_cached_child(struct actiondfs_node *parent,
 	if (!node)
 		return ERR_PTR(-ENOMEM);
 
-	if (!S_ISLNK(record->mode))
-		mutex_init(&node->load_lock);
 	node->parent = parent;
 	node->input_child = record;
 	node->ino = actiondfs_input_child_ino(parent, record);
 	node->size = record->size;
 	if (S_ISLNK(record->mode))
 		node->link_target = record->name + record->name_len + 1;
+	else
+		mutex_init(&node->load_lock);
 	return node;
 }
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1368,9 +1368,16 @@ static ssize_t actiondfs_copy_file_range(struct file *file_in, loff_t pos_in,
 	}
 
 	real_out = file_out->private_data;
+	inode_lock(inode_out);
+	copied = file_remove_privs(file_out);
+	if (copied)
+		goto out_unlock;
 	copied = vfs_copy_file_range(real_in, pos_in, real_out, pos_out, len, 0);
 	if (copied > 0)
 		actiondfs_sync_staged_inode(inode_out, file_inode(real_out));
+
+out_unlock:
+	inode_unlock(inode_out);
 	if (node_in->origin == ACTIONDFS_NODE_INPUT)
 		fput(real_in);
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1158,7 +1158,6 @@ static struct file *actiondfs_open_staged_backing(struct actiondfs_sb_info *sbi,
 	struct file *file;
 	u64 total_start = actiondfs_stat_time_start();
 	u64 phase_start;
-	int err;
 
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_BACKING_OPEN_ATTEMPTS);
 	if (!sbi->stage_path.dentry) {
@@ -1167,11 +1166,12 @@ static struct file *actiondfs_open_staged_backing(struct actiondfs_sb_info *sbi,
 	}
 
 	phase_start = actiondfs_stat_time_start();
-	err = actiondfs_stage_node_path(sbi, node, &real_path);
+	real_path.mnt = sbi->stage_path.mnt;
+	real_path.dentry = READ_ONCE(node->stage_dentry);
 	actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_BACKING_OPEN_LOOKUP_NS,
 				   phase_start);
-	if (err) {
-		file = ERR_PTR(err);
+	if (!real_path.dentry) {
+		file = ERR_PTR(-ENOENT);
 		goto out;
 	}
 
@@ -1180,7 +1180,6 @@ static struct file *actiondfs_open_staged_backing(struct actiondfs_sb_info *sbi,
 				 &real_path, current_cred());
 	actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_BACKING_OPEN_FILE_NS,
 				   phase_start);
-	path_put(&real_path);
 out:
 	if (IS_ERR(file))
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_BACKING_OPEN_FAILURES);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2307,19 +2307,15 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	u64 size = 0;
 	int err;
 
-	err = actiondfs_stage_node_path(sbi, parent, &parent_path);
-	if (err) {
-		if (err == -ENOENT) {
-			actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_NEGATIVE);
-			return NULL;
-		}
-		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_ERRORS);
-		return ERR_PTR(err);
+	parent_path.mnt = sbi->stage_path.mnt;
+	parent_path.dentry = READ_ONCE(parent->stage_dentry);
+	if (!parent_path.dentry) {
+		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_NEGATIVE);
+		return NULL;
 	}
 	err = actiondfs_stage_lookup_child(&parent_path, dentry->d_name.name,
 					   dentry->d_name.len, &real_dentry);
 	if (err) {
-		path_put(&parent_path);
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_ERRORS);
 		return ERR_PTR(err);
 	}
@@ -2395,7 +2391,6 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 
 out_unlock:
 	actiondfs_stage_unlock_child(&parent_path, real_dentry);
-	path_put(&parent_path);
 	if (inode && !IS_ERR(inode) && input_cached) {
 		smp_store_release(&node->cached_dir, input_cached);
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_INPUT_DIR_MERGES);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1848,17 +1848,6 @@ actiondfs_find_blob_path_cache(struct actiondfs_sb_info *sbi,
 	return NULL;
 }
 
-static void actiondfs_get_blob_path_cache_entry_locked(
-	struct actiondfs_sb_info *sbi,
-	struct actiondfs_blob_path_cache_entry *entry,
-	struct path *out)
-{
-	list_move_tail(&entry->list, &actiondfs_blob_path_cache_list);
-	out->mnt = sbi->cas_path.mnt;
-	out->dentry = entry->dentry;
-	path_get(out);
-}
-
 static void actiondfs_evict_blob_path_cache_one_locked(void)
 {
 	struct actiondfs_blob_path_cache_entry *victim;
@@ -1889,21 +1878,19 @@ static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 		return;
 	}
 
-	entry->hash = hash;
-	entry->cas_root = sbi->cas_path.dentry;
-	entry->dentry = dget(path->dentry);
-
 	mutex_lock(&actiondfs_blob_path_cache_lock);
 	existing = actiondfs_find_blob_path_cache(sbi, hash);
 	if (existing) {
-		actiondfs_get_blob_path_cache_entry_locked(sbi, existing, out);
 		mutex_unlock(&actiondfs_blob_path_cache_lock);
 		actiondfs_stat_inc(ACTIONDFS_STAT_BLOB_PATH_CACHE_RACES);
-		actiondfs_free_blob_path_cache_entry(entry);
-		path_put(path);
+		kfree(entry);
+		*out = *path;
 		return;
 	}
 
+	entry->hash = hash;
+	entry->cas_root = sbi->cas_path.dentry;
+	entry->dentry = dget(path->dentry);
 	if (actiondfs_blob_path_cache_count >= ACTIONDFS_BLOB_PATH_CACHE_MAX)
 		actiondfs_evict_blob_path_cache_one_locked();
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -932,7 +932,7 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_children *child
 	if (children->count == children->capacity) {
 		if (children->capacity > U32_MAX / 2)
 			return -EOVERFLOW;
-		capacity = children->capacity ? children->capacity * 2 : 8;
+		capacity = children->capacity ? children->capacity * 2 : 4;
 		entries = krealloc_array(children->entries, capacity,
 					 sizeof(*entries), GFP_KERNEL);
 		if (!entries)

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1593,17 +1593,14 @@ static int actiondfs_pb_skip(const u8 *data, size_t len, size_t *pos, u64 wire)
 	case 0:
 		return actiondfs_pb_read_varint(data, len, pos, &value);
 	case 1:
-		if (len - *pos < 8)
+	case 5:
+		field_len = wire == 1 ? 8 : 4;
+		if (len - *pos < field_len)
 			return -EINVAL;
-		*pos += 8;
+		*pos += field_len;
 		return 0;
 	case 2:
 		return actiondfs_pb_read_len(data, len, pos, &field, &field_len);
-	case 5:
-		if (len - *pos < 4)
-			return -EINVAL;
-		*pos += 4;
-		return 0;
 	default:
 		return -EINVAL;
 	}

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1314,8 +1314,10 @@ static ssize_t actiondfs_write_iter(struct kiocb *iocb, struct iov_iter *from)
 	total_start = actiondfs_stat_time_start();
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_WRITE_CALLS);
 	file = iocb->ki_filp->private_data;
+	inode_lock(inode);
 	nwritten = backing_file_write_iter(file, from, iocb,
 					   iocb->ki_flags, &ctx);
+	inode_unlock(inode);
 	actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_WRITE_TOTAL_NS,
 				   total_start);
 	return nwritten;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2706,10 +2706,6 @@ static int actiondfs_rename(struct mnt_idmap *idmap, struct inode *old_dir,
 						 &new_parent_path);
 	if (err)
 		goto out_done;
-	if (old_parent_path.mnt != new_parent_path.mnt) {
-		err = -EXDEV;
-		goto out_put_new_path;
-	}
 	err = mnt_want_write(old_parent_path.mnt);
 	if (err)
 		goto out_put_new_path;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2692,13 +2692,20 @@ static int actiondfs_rename(struct mnt_idmap *idmap, struct inode *old_dir,
 	if (new_node && new_node->origin != ACTIONDFS_NODE_STAGED)
 		return -EROFS;
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_RENAME_CALLS);
-	err = actiondfs_stage_node_path(sbi, old_parent, &old_parent_path);
-	if (err)
+	if (!sbi->stage_path.dentry) {
+		err = -EROFS;
 		goto out_done;
+	}
+	old_parent_path.mnt = sbi->stage_path.mnt;
+	old_parent_path.dentry = READ_ONCE(old_parent->stage_dentry);
+	if (!old_parent_path.dentry) {
+		err = -ENOENT;
+		goto out_done;
+	}
 	err = actiondfs_ensure_stage_parent_path(sbi, new_parent,
 						 &new_parent_path);
 	if (err)
-		goto out_put_old_path;
+		goto out_done;
 	if (old_parent_path.mnt != new_parent_path.mnt) {
 		err = -EXDEV;
 		goto out_put_new_path;
@@ -2778,8 +2785,6 @@ out_drop_write:
 	mnt_drop_write(old_parent_path.mnt);
 out_put_new_path:
 	path_put(&new_parent_path);
-out_put_old_path:
-	path_put(&old_parent_path);
 out_done:
 	if (err)
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_RENAME_FAILURES);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2311,10 +2311,10 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_ERRORS);
 		return ERR_PTR(err);
 	}
-	if (!d_inode(real_dentry))
+	real_inode = d_inode(real_dentry);
+	if (!real_inode)
 		goto out_negative;
 
-	real_inode = d_inode(real_dentry);
 	mode = real_inode->i_mode;
 	if (S_ISDIR(mode)) {
 		mode = S_IFDIR | (mode & S_IALLUGO);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1720,6 +1720,7 @@ static int actiondfs_parse_reapi_cached_child(struct actiondfs_cached_dir *paren
 {
 	struct actiondfs_parsed_child child;
 	struct actiondfs_cached_children *children;
+	bool regular;
 	int err;
 
 	err = actiondfs_parse_reapi_child_fields(data, len, &child, mode);
@@ -1731,7 +1732,8 @@ static int actiondfs_parse_reapi_cached_child(struct actiondfs_cached_dir *paren
 			S_IFLNK | 0777, child.symlink.target_len,
 			NULL, child.symlink.target);
 
-	if (S_ISREG(mode)) {
+	regular = S_ISREG(mode);
+	if (regular) {
 		children = &parent->files;
 		mode |= child.executable ? 0555 : 0444;
 	} else {
@@ -1742,7 +1744,7 @@ static int actiondfs_parse_reapi_cached_child(struct actiondfs_cached_dir *paren
 					    mode, child.digest.size,
 					    child.digest.hash, NULL);
 	if (!err)
-		actiondfs_stat_inc(S_ISREG(mode) ?
+		actiondfs_stat_inc(regular ?
 				  ACTIONDFS_STAT_CACHED_FILE_RECORDS :
 				  ACTIONDFS_STAT_CACHED_DIR_RECORDS);
 	return err;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1082,7 +1082,7 @@ static struct file *actiondfs_open_backing_cas_blob(struct actiondfs_sb_info *sb
 		real_inode = d_inode(real_path.dentry);
 		real_size = real_inode ? i_size_read(real_inode) : -1;
 		if (!real_inode || !S_ISREG(real_inode->i_mode) ||
-		    real_size < 0 || (u64)real_size != expected_size) {
+		    (u64)real_size != expected_size) {
 			dput(real_path.dentry);
 			file = ERR_PTR(-EIO);
 			break;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -113,7 +113,7 @@ struct actiondfs_node {
 	umode_t mode;
 	union {
 		char *link_target;
-		atomic64_t stage_generation;
+		u64 stage_generation;
 	};
 	const struct actiondfs_cached_child *input_child;
 	struct mutex load_lock;
@@ -490,7 +490,7 @@ static void actiondfs_set_stage_dentry(struct actiondfs_node *node,
 
 static void actiondfs_note_stage_change(struct actiondfs_node *node)
 {
-	atomic64_inc(&node->stage_generation);
+	node->stage_generation++;
 }
 
 static int actiondfs_stage_node_path(struct actiondfs_sb_info *sbi,
@@ -2998,7 +2998,7 @@ static int actiondfs_open_stage_file(struct inode *inode,
 	struct actiondfs_sb_info *sbi = actiondfs_sbi(inode->i_sb);
 	struct path real_path;
 	struct file *file;
-	u64 generation = atomic64_read(&dir->stage_generation);
+	u64 generation = dir->stage_generation;
 	int err;
 
 	if ((dir_file->stage_file || dir_file->stage_eof) &&

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1547,6 +1547,19 @@ static int actiondfs_pb_read_varint(const u8 *data, size_t len,
 	return -EINVAL;
 }
 
+static int actiondfs_pb_read_key(const u8 *data, size_t len,
+				 size_t *pos, u64 *key)
+{
+	int err;
+
+	err = actiondfs_pb_read_varint(data, len, pos, key);
+	if (err)
+		return err;
+	if (!(*key >> 3) || (*key >> 3) > 0x1fffffff || (*key & 7) > 5)
+		return -EINVAL;
+	return 0;
+}
+
 static int actiondfs_pb_read_len(const u8 *data, size_t len, size_t *pos,
 				 const u8 **field, size_t *field_len)
 {
@@ -1621,7 +1634,7 @@ static int actiondfs_parse_reapi_digest(const u8 *data, size_t len,
 		size_t field_len;
 		u64 key;
 
-		err = actiondfs_pb_read_varint(data, len, &pos, &key);
+		err = actiondfs_pb_read_key(data, len, &pos, &key);
 		if (err)
 			return err;
 
@@ -1670,7 +1683,7 @@ static int actiondfs_parse_reapi_child_fields(const u8 *data, size_t len,
 		u64 key;
 		u64 value;
 
-		err = actiondfs_pb_read_varint(data, len, &pos, &key);
+		err = actiondfs_pb_read_key(data, len, &pos, &key);
 		if (err)
 			return err;
 
@@ -2004,7 +2017,7 @@ static int actiondfs_build_cached_dir(struct actiondfs_sb_info *sbi,
 		size_t field_len;
 		u64 key;
 
-		err = actiondfs_pb_read_varint(buffer, len, &pos, &key);
+		err = actiondfs_pb_read_key(buffer, len, &pos, &key);
 		if (err)
 			goto out_buffer;
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2199,8 +2199,7 @@ static struct inode *actiondfs_iget(struct super_block *sb,
 	if (!inode)
 		return ERR_PTR(-ENOMEM);
 	if (!(inode->i_state & I_NEW)) {
-		if (input_child)
-			actiondfs_free_node(node);
+		actiondfs_free_node(node);
 		return inode;
 	}
 
@@ -2373,8 +2372,6 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 		goto out_error;
 	}
 	if (inode->i_private != node) {
-		if (!input_cached)
-			actiondfs_free_node(node);
 		node = inode->i_private;
 		actiondfs_set_stage_dentry(node, real_dentry);
 	}

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2894,6 +2894,8 @@ static int actiondfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 		goto out;
 
 	real_attr = *attr;
+	if (real_attr.ia_valid & (ATTR_KILL_SUID | ATTR_KILL_SGID))
+		real_attr.ia_valid &= ~ATTR_MODE;
 	if (real_attr.ia_valid & ATTR_FILE) {
 		if (!real_attr.ia_file || !real_attr.ia_file->private_data) {
 			err = -EBADF;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1220,11 +1220,6 @@ static ssize_t actiondfs_read_iter(struct kiocb *iocb, struct iov_iter *to)
 		total_start = actiondfs_stat_time_start();
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_READ_CALLS);
 		file = iocb->ki_filp->private_data;
-		if (!file) {
-			actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_READ_TOTAL_NS,
-						   total_start);
-			return -EBADF;
-		}
 		nread = backing_file_read_iter(file, to, iocb, iocb->ki_flags,
 					       &ctx);
 		if (nread > 0)
@@ -1317,11 +1312,6 @@ static ssize_t actiondfs_write_iter(struct kiocb *iocb, struct iov_iter *from)
 	total_start = actiondfs_stat_time_start();
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_WRITE_CALLS);
 	file = iocb->ki_filp->private_data;
-	if (!file) {
-		actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_WRITE_TOTAL_NS,
-					   total_start);
-		return -EBADF;
-	}
 	nwritten = backing_file_write_iter(file, from, iocb,
 					   iocb->ki_flags, &ctx);
 	actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_WRITE_TOTAL_NS,
@@ -1367,8 +1357,6 @@ static ssize_t actiondfs_copy_file_range(struct file *file_in, loff_t pos_in,
 		real_in = actiondfs_get_node_blob_file(node_in, file_in);
 	} else {
 		real_in = file_in->private_data;
-		if (!real_in)
-			real_in = ERR_PTR(-EBADF);
 	}
 	if (IS_ERR(real_in)) {
 		copied = PTR_ERR(real_in);
@@ -1376,15 +1364,9 @@ static ssize_t actiondfs_copy_file_range(struct file *file_in, loff_t pos_in,
 	}
 
 	real_out = file_out->private_data;
-	if (!real_out) {
-		copied = -EBADF;
-		goto out_put_in;
-	}
-
 	copied = vfs_copy_file_range(real_in, pos_in, real_out, pos_out, len, 0);
 	if (copied > 0)
 		actiondfs_sync_staged_inode(inode_out, file_inode(real_out));
-out_put_in:
 	if (node_in->origin == ACTIONDFS_NODE_INPUT)
 		fput(real_in);
 
@@ -1424,11 +1406,6 @@ static ssize_t actiondfs_splice_read(struct file *actiondfs_file, loff_t *ppos,
 
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_SPLICE_READ_CALLS);
 		file = actiondfs_file->private_data;
-		if (!file) {
-			actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_SPLICE_READ_TOTAL_NS,
-						   total_start);
-			return -EBADF;
-		}
 		init_sync_kiocb(&backing_iocb, actiondfs_file);
 		backing_iocb.ki_pos = pos;
 		nread = backing_file_splice_read(file, &backing_iocb, pipe,
@@ -1502,12 +1479,6 @@ static int actiondfs_mmap(struct file *actiondfs_file,
 
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_MMAP_CALLS);
 		file = actiondfs_file->private_data;
-		if (!file) {
-			actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_MMAP_FAILURES);
-			actiondfs_stat_add_elapsed(ACTIONDFS_STAT_STAGE_MMAP_TOTAL_NS,
-						   total_start);
-			return -EBADF;
-		}
 		err = backing_file_mmap(file, vma, &ctx);
 		if (err)
 			actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_MMAP_FAILURES);
@@ -2901,8 +2872,6 @@ static int actiondfs_fsync(struct file *file, loff_t start, loff_t end,
 		if (node->origin != ACTIONDFS_NODE_STAGED)
 			return 0;
 		backing_file = file->private_data;
-		if (!backing_file)
-			return -EBADF;
 		return vfs_fsync_range(backing_file, start, end, datasync);
 	}
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2417,6 +2417,7 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 		node->link_target = link_target;
 		link_target = NULL;
 	}
+	node->stage_dentry = dget(real_dentry);
 	inode = actiondfs_iget(dir->i_sb, node);
 	if (IS_ERR(inode)) {
 		err = PTR_ERR(inode);
@@ -2427,13 +2428,13 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 		if (!input_cached)
 			actiondfs_free_node(node);
 		node = inode->i_private;
+		actiondfs_set_stage_dentry(node, real_dentry);
 	}
 	if (S_ISDIR(mode)) {
 		node->mode = mode;
 		inode->i_mode = mode;
 	}
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_HITS);
-	actiondfs_set_stage_dentry(node, real_dentry);
 
 out_unlock:
 	actiondfs_stage_unlock_child(&parent_path, real_dentry);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -404,9 +404,8 @@ static const struct inode_operations actiondfs_file_iops;
 static const struct inode_operations actiondfs_symlink_iops;
 static const struct file_operations actiondfs_dir_fops;
 static const struct file_operations actiondfs_file_fops;
-static int actiondfs_get_cached_blob_path(struct actiondfs_sb_info *sbi,
-					  const char *hash,
-					  struct path *out);
+static struct dentry *actiondfs_get_cached_blob_dentry(
+	struct actiondfs_sb_info *sbi, const char *hash);
 static void actiondfs_drop_cached_blob_path(struct actiondfs_sb_info *sbi,
 					   const char *hash);
 
@@ -1069,10 +1068,12 @@ static struct file *actiondfs_open_backing_cas_blob(struct actiondfs_sb_info *sb
 
 		actiondfs_stat_inc(ACTIONDFS_STAT_BLOB_OPEN_ATTEMPTS);
 		path_start = actiondfs_stat_time_start();
-		err = actiondfs_get_cached_blob_path(sbi, hash, &real_path);
+		real_path.mnt = sbi->cas_path.mnt;
+		real_path.dentry = actiondfs_get_cached_blob_dentry(sbi, hash);
 		actiondfs_stat_add_elapsed(ACTIONDFS_STAT_BLOB_OPEN_BACKING_PATH_NS,
 					   path_start);
-		if (err) {
+		if (IS_ERR(real_path.dentry)) {
+			err = PTR_ERR(real_path.dentry);
 			file = ERR_PTR(err);
 			goto retry;
 		}
@@ -1081,7 +1082,7 @@ static struct file *actiondfs_open_backing_cas_blob(struct actiondfs_sb_info *sb
 		real_size = real_inode ? i_size_read(real_inode) : -1;
 		if (!real_inode || !S_ISREG(real_inode->i_mode) ||
 		    real_size < 0 || (u64)real_size != expected_size) {
-			path_put(&real_path);
+			dput(real_path.dentry);
 			file = ERR_PTR(-EIO);
 			break;
 		}
@@ -1091,7 +1092,7 @@ static struct file *actiondfs_open_backing_cas_blob(struct actiondfs_sb_info *sb
 					 current_cred());
 		actiondfs_stat_add_elapsed(ACTIONDFS_STAT_BLOB_OPEN_BACKING_FILE_NS,
 					   open_start);
-		path_put(&real_path);
+		dput(real_path.dentry);
 		if (!IS_ERR(file))
 			break;
 
@@ -1865,18 +1866,15 @@ static void actiondfs_evict_blob_path_cache_one_locked(void)
 
 static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 					     const char *hash,
-					     const struct path *path,
-					     struct path *out)
+					     struct dentry *dentry)
 {
 	struct actiondfs_blob_path_cache_entry *entry;
 	struct actiondfs_blob_path_cache_entry *existing;
 	unsigned long key;
 
 	entry = kmalloc(sizeof(*entry), GFP_KERNEL);
-	if (!entry) {
-		*out = *path;
+	if (!entry)
 		return;
-	}
 
 	mutex_lock(&actiondfs_blob_path_cache_lock);
 	existing = actiondfs_find_blob_path_cache(sbi, hash);
@@ -1884,13 +1882,12 @@ static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 		mutex_unlock(&actiondfs_blob_path_cache_lock);
 		actiondfs_stat_inc(ACTIONDFS_STAT_BLOB_PATH_CACHE_RACES);
 		kfree(entry);
-		*out = *path;
 		return;
 	}
 
 	entry->hash = hash;
 	entry->cas_root = sbi->cas_path.dentry;
-	entry->dentry = dget(path->dentry);
+	entry->dentry = dget(dentry);
 	if (actiondfs_blob_path_cache_count >= ACTIONDFS_BLOB_PATH_CACHE_MAX)
 		actiondfs_evict_blob_path_cache_one_locked();
 
@@ -1899,15 +1896,14 @@ static void actiondfs_insert_blob_path_cache(struct actiondfs_sb_info *sbi,
 	list_add_tail(&entry->list, &actiondfs_blob_path_cache_list);
 	actiondfs_blob_path_cache_count++;
 	actiondfs_stat_inc(ACTIONDFS_STAT_BLOB_PATH_CACHE_INSERTS);
-	*out = *path;
 	mutex_unlock(&actiondfs_blob_path_cache_lock);
 }
 
-static int actiondfs_get_cached_blob_path(struct actiondfs_sb_info *sbi,
-					  const char *hash,
-					  struct path *out)
+static struct dentry *actiondfs_get_cached_blob_dentry(
+	struct actiondfs_sb_info *sbi, const char *hash)
 {
 	struct actiondfs_blob_path_cache_entry *entry;
+	struct dentry *dentry;
 	char path[ACTIONDFS_SHARDED_HASH_PATH_LEN + 1];
 	struct path real_path;
 	int err;
@@ -1915,12 +1911,10 @@ static int actiondfs_get_cached_blob_path(struct actiondfs_sb_info *sbi,
 	rcu_read_lock();
 	entry = actiondfs_find_blob_path_cache(sbi, hash);
 	if (entry) {
-		out->mnt = sbi->cas_path.mnt;
-		out->dentry = entry->dentry;
-		path_get(out);
+		dentry = dget(entry->dentry);
 		rcu_read_unlock();
 		actiondfs_stat_inc(ACTIONDFS_STAT_BLOB_PATH_CACHE_HITS);
-		return 0;
+		return dentry;
 	}
 	rcu_read_unlock();
 
@@ -1930,10 +1924,11 @@ static int actiondfs_get_cached_blob_path(struct actiondfs_sb_info *sbi,
 			      path, LOOKUP_FOLLOW | LOOKUP_NO_SYMLINKS |
 				    LOOKUP_NO_XDEV, &real_path);
 	if (err)
-		return err;
+		return ERR_PTR(err);
 
-	actiondfs_insert_blob_path_cache(sbi, hash, &real_path, out);
-	return 0;
+	actiondfs_insert_blob_path_cache(sbi, hash, real_path.dentry);
+	mntput(real_path.mnt);
+	return real_path.dentry;
 }
 
 static void actiondfs_drop_cached_blob_path(struct actiondfs_sb_info *sbi,

--- a/test/STRESS_TIMINGS.md
+++ b/test/STRESS_TIMINGS.md
@@ -1,22 +1,22 @@
 # Executor Timing Summary
 
-- Generated: `2026-07-30 21:27:31 EDT`
+- Generated: `2026-08-01 15:38:43 EDT`
 - Mode: `vm`
 - Execute records parsed: `36`
 - Unique action digests: `36`
-- Source log: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-vm-e2e.0KEOIs/darwin-actiond-vm.log`
-- Command: `ACTIOND_E2E_KEEP_TMP=1 ACTIOND_REPO_BAZEL_FLAGS="--config=remote --config=executor_timing_logs" tools/e2e.sh vm`
+- Source log: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-vm-e2e.0mQ13T/darwin-actiond-vm.log`
+- Command: `ACTIOND_E2E_KEEP_TMP=1 ACTIOND_E2E_ACTIONDFS_STATS_PATH=/private/tmp/actiondfs-round-six-final.stats ACTIOND_REPO_BAZEL_FLAGS="--config=remote --config=executor_timing_logs --jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" tools/e2e.sh vm`
 
 ## Stage Timing
 
 All timing values are milliseconds unless noted.
 
-| Stage                 |   Min |    p25 |    p50 |    p75 |    p95 |   Mean |     Max | Share of summed total |
-| --------------------- | ----: | -----: | -----: | -----: | -----: | -----: | ------: | --------------------: |
-| total                 | 4.168 | 20.570 | 31.554 | 39.426 | 57.708 | 37.878 | 284.074 |                100.0% |
-| input fetch/setup     | 0.271 |  0.302 |  0.354 |  0.737 |  3.949 |  0.999 |   7.604 |                  2.6% |
-| execute               | 3.484 | 18.485 | 27.423 | 35.506 | 51.711 | 34.130 | 281.650 |                 90.1% |
-| output upload/collect | 0.083 |  0.153 |  0.791 |  2.121 | 15.584 |  2.748 |  20.587 |                  7.3% |
+| Stage                 |   Min |   p25 |    p50 |    p75 |    p95 |   Mean |    Max | Share of summed total |
+| --------------------- | ----: | ----: | -----: | -----: | -----: | -----: | -----: | --------------------: |
+| total                 | 2.800 | 7.638 | 15.403 | 21.545 | 44.323 | 17.931 | 96.064 |                100.0% |
+| input fetch/setup     | 0.265 | 0.304 |  0.320 |  0.369 |  0.718 |  0.385 |  0.774 |                  2.1% |
+| execute               | 2.239 | 6.911 | 14.545 | 19.252 | 36.624 | 16.418 | 94.466 |                 91.6% |
+| output upload/collect | 0.073 | 0.185 |  0.417 |  0.947 |  5.558 |  1.128 | 10.451 |                  6.3% |
 
 ## Mount And Output Counts
 
@@ -30,140 +30,140 @@ All timing values are milliseconds unless noted.
 
 | Stress Case                | Actions | Total p25 | Total p50 | Total p75 | Total p95 | Input p50 | Execute p50 | Output p50 | Mounts p50 |
 | -------------------------- | ------: | --------: | --------: | --------: | --------: | --------: | ----------: | ---------: | ---------: |
-| aggregate                  |       1 |    26.055 |    26.055 |    26.055 |    26.055 |     0.285 |      25.686 |      0.083 |          4 |
-| bare_individual_files      |       4 |    27.443 |    32.164 |    33.786 |    34.289 |     0.317 |      29.378 |      0.468 |          4 |
-| filesystem_regression      |       1 |   284.074 |   284.074 |   284.074 |   284.074 |     0.308 |     281.650 |      2.116 |          4 |
-| generated_file_producer    |       1 |    34.346 |    34.346 |    34.346 |    34.346 |     0.645 |      26.347 |      7.354 |          4 |
-| generated_individual_files |       4 |    32.756 |    39.116 |    45.676 |    56.690 |     0.559 |      36.750 |      1.019 |          4 |
-| generated_tree_producer    |       1 |    44.460 |    44.460 |    44.460 |    44.460 |     1.335 |      32.007 |     11.117 |          4 |
-| generated_tree_reuse       |       8 |    13.997 |    26.427 |    41.653 |    55.203 |     0.655 |      24.178 |      0.603 |          4 |
-| mixed_all                  |       1 |    20.897 |    20.897 |    20.897 |    20.897 |     0.271 |      17.814 |      2.812 |          4 |
-| nested_individual_files    |       8 |    26.163 |    32.731 |    43.742 |    57.088 |     0.318 |      30.859 |      1.144 |          4 |
-| pids_one_regression        |       1 |    13.369 |    13.369 |    13.369 |    13.369 |     0.305 |      12.916 |      0.148 |          4 |
-| source_dir_tree            |       4 |    23.606 |    23.986 |    27.969 |    37.392 |     0.543 |      22.857 |      0.377 |          4 |
-| symlink_input_consumer     |       1 |     4.168 |     4.168 |     4.168 |     4.168 |     0.272 |       3.484 |      0.412 |          4 |
-| timeout_recovery           |       1 |    27.716 |    27.716 |    27.716 |    27.716 |     3.338 |      23.844 |      0.533 |          4 |
+| aggregate                  |       1 |    21.765 |    21.765 |    21.765 |    21.765 |     0.334 |      21.358 |      0.073 |          4 |
+| bare_individual_files      |       4 |    14.152 |    15.531 |    19.003 |    25.750 |     0.310 |      14.864 |      0.350 |          4 |
+| filesystem_regression      |       1 |    96.064 |    96.064 |    96.064 |    96.064 |     0.403 |      94.466 |      1.194 |          4 |
+| generated_file_producer    |       1 |    40.791 |    40.791 |    40.791 |    40.791 |     0.729 |      34.097 |      5.964 |          4 |
+| generated_individual_files |       4 |     4.759 |     5.354 |     8.250 |    14.238 |     0.508 |       4.325 |      0.336 |          4 |
+| generated_tree_producer    |       1 |    54.918 |    54.918 |    54.918 |    54.918 |     0.265 |      44.202 |     10.451 |          4 |
+| generated_tree_reuse       |       8 |     6.399 |     9.482 |    15.911 |    21.792 |     0.323 |       8.946 |      0.179 |          4 |
+| mixed_all                  |       1 |    21.317 |    21.317 |    21.317 |    21.317 |     0.309 |      18.169 |      2.839 |          4 |
+| nested_individual_files    |       8 |     7.202 |    14.776 |    19.407 |    23.647 |     0.315 |      13.525 |      0.691 |          4 |
+| pids_one_regression        |       1 |     8.981 |     8.981 |     8.981 |     8.981 |     0.328 |       8.493 |      0.160 |          4 |
+| source_dir_tree            |       4 |    15.268 |    17.018 |    19.448 |    24.224 |     0.325 |      16.561 |      0.339 |          4 |
+| symlink_input_consumer     |       1 |     2.800 |     2.800 |     2.800 |     2.800 |     0.287 |       2.239 |      0.274 |          4 |
+| timeout_recovery           |       1 |    22.876 |    22.876 |    22.876 |    22.876 |     0.683 |      21.918 |      0.275 |          4 |
 
 ## Visible Overhead Estimate
 
 `process/io` is excluded here because it is mostly the action process runtime plus stdout/stderr drain.
 
-| Metric                    |   Min |    p25 |    p50 |    p75 |    p95 |   Mean |    Max | Share of summed total |
-| ------------------------- | ----: | -----: | -----: | -----: | -----: | -----: | -----: | --------------------: |
-| fixed overhead, no wait   | 2.646 | 11.225 | 21.477 | 32.465 | 48.440 | 23.086 | 53.829 |                 60.9% |
-| fixed overhead, with wait | 2.646 | 12.156 | 21.477 | 32.465 | 49.602 | 23.380 | 53.829 |                 61.7% |
+| Metric                    |   Min |   p25 |   p50 |    p75 |    p95 |   Mean |    Max | Share of summed total |
+| ------------------------- | ----: | ----: | ----: | -----: | -----: | -----: | -----: | --------------------: |
+| fixed overhead, no wait   | 1.922 | 4.703 | 9.708 | 15.758 | 27.705 | 11.656 | 37.169 |                 65.0% |
+| fixed overhead, with wait | 1.922 | 4.703 | 9.708 | 16.919 | 27.705 | 11.856 | 37.169 |                 66.1% |
 
 ## Runner Timing
 
 These values split the `execute` bucket. `child setup` includes successful `execve`; `process/io` starts after close-on-exec confirmation and includes action runtime and stdout/stderr drain.
 
-| Runner Stage   |   Min |   p25 |   p50 |    p75 |    p95 |   Mean |     Max | Share of execute |
-| -------------- | ----: | ----: | ----: | -----: | -----: | -----: | ------: | ---------------: |
-| parent prepare | 0.088 | 0.121 | 0.502 | 10.362 | 27.204 |  6.767 |  27.793 |            19.8% |
-| fork           | 0.313 | 0.521 | 0.928 |  1.645 |  3.923 |  1.339 |   5.006 |             3.9% |
-| child setup    | 0.946 | 4.264 | 7.329 | 19.516 | 28.501 | 11.233 |  31.908 |            32.9% |
-| process/io     | 0.034 | 2.374 | 5.509 |  9.156 | 22.220 | 14.455 | 272.967 |            42.4% |
-| wait           | 0.000 | 0.000 | 0.000 |  0.000 |  3.067 |  0.294 |   4.203 |             0.9% |
-| stdio digest   | 0.000 | 0.000 | 0.000 |  0.001 |  0.001 |  0.000 |   0.001 |             0.0% |
+| Runner Stage   |   Min |   p25 |   p50 |   p75 |    p95 |  Mean |    Max | Share of execute |
+| -------------- | ----: | ----: | ----: | ----: | -----: | ----: | -----: | ---------------: |
+| parent prepare | 0.099 | 0.117 | 0.270 | 6.675 | 22.877 | 4.427 | 24.358 |            27.0% |
+| fork           | 0.134 | 0.218 | 0.264 | 0.529 |  1.192 | 0.441 |  1.442 |             2.7% |
+| child setup    | 0.819 | 1.635 | 2.306 | 5.647 | 18.052 | 5.275 | 18.704 |            32.1% |
+| process/io     | 0.600 | 1.487 | 2.439 | 4.551 | 13.859 | 6.046 | 88.532 |            36.8% |
+| wait           | 0.000 | 0.000 | 0.000 | 0.000 |  0.384 | 0.200 |  5.675 |             1.2% |
+| stdio digest   | 0.000 | 0.000 | 0.000 | 0.001 |  0.001 | 0.000 |  0.001 |             0.0% |
 
 | Stress Case                | Digest         | Parent Prep |  Fork | Child Setup | Process/IO |  Wait | Stdio Digest | Setup Signaled |
 | -------------------------- | -------------- | ----------: | ----: | ----------: | ---------: | ----: | -----------: | -------------- |
-| aggregate                  | `2fa3a4511718` |       0.109 | 0.404 |      22.475 |      2.673 | 0.000 |        0.001 | True           |
-| bare_individual_files      | `1a9a1d7d45e4` |      26.561 | 0.862 |       4.883 |      0.125 | 0.000 |        0.001 | True           |
-| bare_individual_files      | `293475ee06bb` |      14.018 | 5.006 |       1.000 |     10.215 | 0.000 |        0.001 | True           |
-| bare_individual_files      | `96c424f1edad` |       4.347 | 0.547 |       8.585 |      1.354 | 0.000 |        0.001 | True           |
-| bare_individual_files      | `ccdb7626dedd` |       0.119 | 1.077 |      24.906 |      2.374 | 0.000 |        0.000 | True           |
-| filesystem_regression      | `9a580d312f78` |       4.558 | 1.515 |       2.578 |    272.967 | 0.000 |        0.001 | True           |
-| generated_file_producer    | `174bffc360c9` |       9.937 | 0.459 |       2.482 |     13.451 | 0.000 |        0.000 | True           |
-| generated_individual_files | `2d4ce7a45898` |       0.180 | 1.661 |      28.695 |      7.672 | 0.000 |        0.001 | True           |
-| generated_individual_files | `58d933f8a1cc` |       0.234 | 0.522 |      28.436 |     22.490 | 0.000 |        0.001 | True           |
-| generated_individual_files | `ebe0486999bc` |      11.639 | 1.753 |       2.042 |      3.249 | 0.000 |        0.000 | True           |
-| generated_individual_files | `ef34017f746a` |      27.624 | 1.523 |       4.050 |      2.008 | 0.000 |        0.001 | True           |
-| generated_tree_producer    | `db960becfd36` |       7.452 | 0.519 |       8.340 |     15.662 | 0.000 |        0.001 | True           |
-| generated_tree_reuse       | `056bce18df22` |      19.927 | 1.252 |       4.336 |      8.929 | 0.000 |        0.000 | True           |
-| generated_tree_reuse       | `1c8778f3cc78` |       0.101 | 0.447 |       7.538 |      0.034 | 0.000 |        0.000 | True           |
-| generated_tree_reuse       | `21983588efc6` |       1.900 | 0.559 |      27.173 |     22.093 | 0.000 |        0.000 | True           |
-| generated_tree_reuse       | `46d362087f03` |       0.099 | 0.333 |       6.882 |     22.130 | 4.203 |        0.000 | True           |
-| generated_tree_reuse       | `5eba25364668` |       0.088 | 3.770 |       6.620 |      3.326 | 0.000 |        0.000 | True           |
-| generated_tree_reuse       | `94a4a5794423` |       0.223 | 1.235 |       6.501 |      6.261 | 0.000 |        0.001 | True           |
-| generated_tree_reuse       | `e89401eb9021` |      26.148 | 2.621 |       3.050 |      6.616 | 0.000 |        0.000 | True           |
-| generated_tree_reuse       | `f433d0b3a994` |       0.111 | 2.246 |       5.474 |      4.559 | 0.000 |        0.000 | True           |
-| mixed_all                  | `c91e0b696fc8` |       0.100 | 0.735 |       7.120 |      9.836 | 0.000 |        0.001 | True           |
-| nested_individual_files    | `3dff464548c3` |       0.116 | 0.638 |      31.908 |      5.219 | 0.000 |        0.000 | True           |
-| nested_individual_files    | `624772a8ae88` |       0.925 | 1.559 |       4.860 |      3.957 | 3.424 |        0.001 | True           |
-| nested_individual_files    | `6875f2d910c8` |      27.793 | 2.406 |       2.728 |      3.273 | 0.000 |        0.000 | True           |
-| nested_individual_files    | `7c722534d2c8` |       1.890 | 1.640 |      18.237 |      2.374 | 0.000 |        0.001 | True           |
-| nested_individual_files    | `b77221109b6c` |       0.181 | 0.512 |       7.987 |     21.800 | 0.000 |        0.001 | True           |
-| nested_individual_files    | `c66b33449ee8` |       1.744 | 0.641 |      15.435 |      6.701 | 0.000 |        0.000 | True           |
-| nested_individual_files    | `e9b5b4f432a6` |      27.063 | 4.382 |       1.346 |      5.800 | 2.948 |        0.000 | True           |
-| nested_individual_files    | `f904af8dd963` |       0.091 | 2.044 |      20.130 |      8.925 | 0.000 |        0.000 | True           |
-| pids_one_regression        | `cd3cb4b17ba0` |       0.142 | 0.519 |      11.147 |      1.071 | 0.000 |        0.000 | True           |
-| source_dir_tree            | `0744164ec172` |       0.121 | 0.354 |      19.792 |      2.694 | 0.000 |        0.001 | True           |
-| source_dir_tree            | `25d07a1a15b9` |       0.676 | 0.313 |      19.439 |      2.239 | 0.000 |        0.000 | True           |
-| source_dir_tree            | `5d07305214c6` |       0.128 | 0.824 |      12.161 |      8.702 | 0.000 |        0.000 | True           |
-| source_dir_tree            | `c7d0b3212bf8` |      26.715 | 0.993 |       5.355 |      5.927 | 0.000 |        0.000 | True           |
-| symlink_input_consumer     | `5c31db5029b1` |       0.234 | 0.781 |       0.946 |      1.482 | 0.000 |        0.001 | True           |
-| timeout_recovery           | `01ac7dd6dd9b` |       0.328 | 1.536 |      19.747 |      2.189 | 0.000 |        0.001 | True           |
+| aggregate                  | `1aaef86306e4` |       0.129 | 0.241 |      18.301 |      2.642 | 0.000 |        0.001 | True           |
+| bare_individual_files      | `066472414ea9` |      10.339 | 0.445 |       2.710 |      0.781 | 0.000 |        0.000 | True           |
+| bare_individual_files      | `2bf32e1a816e` |       0.117 | 0.212 |      14.195 |      0.867 | 0.000 |        0.000 | True           |
+| bare_individual_files      | `5f0c7908f803` |      23.502 | 0.182 |       2.102 |      1.158 | 0.000 |        0.001 | True           |
+| bare_individual_files      | `9ddf9d0661e8` |       4.309 | 0.963 |       2.074 |      3.677 | 0.000 |        0.001 | True           |
+| filesystem_regression      | `a889da71fec5` |       3.170 | 0.628 |       2.111 |     88.532 | 0.000 |        0.000 | True           |
+| generated_file_producer    | `ce0a87dadeaf` |      22.669 | 0.256 |       2.482 |      8.666 | 0.000 |        0.001 | True           |
+| generated_individual_files | `07134f6f78fb` |      10.292 | 0.473 |       2.257 |      1.502 | 0.000 |        0.000 | True           |
+| generated_individual_files | `1ada216cf349` |       0.122 | 1.442 |       1.107 |      1.541 | 0.000 |        0.000 | True           |
+| generated_individual_files | `2fcd9276e686` |       0.109 | 1.348 |       0.852 |      2.077 | 0.000 |        0.001 | True           |
+| generated_individual_files | `963770016a83` |       0.137 | 0.442 |       0.819 |      2.043 | 0.000 |        0.000 | True           |
+| generated_tree_producer    | `a0e22e4a2449` |      24.358 | 0.134 |       1.961 |     17.723 | 0.000 |        0.001 | True           |
+| generated_tree_reuse       | `234fe92db0c4` |       8.840 | 0.537 |       2.457 |      2.662 | 0.000 |        0.001 | True           |
+| generated_tree_reuse       | `307f8dd32223` |       4.255 | 0.179 |       1.653 |      4.424 | 0.000 |        0.001 | True           |
+| generated_tree_reuse       | `31ecae29e592` |       0.130 | 0.196 |       4.773 |      2.221 | 0.000 |        0.000 | True           |
+| generated_tree_reuse       | `3a94355a7850` |       0.099 | 0.195 |       1.732 |      1.411 | 0.000 |        0.001 | True           |
+| generated_tree_reuse       | `3f5910cbd10a` |       0.261 | 0.255 |       1.989 |      1.341 | 0.000 |        0.000 | True           |
+| generated_tree_reuse       | `958cf2efa665` |       0.157 | 0.228 |      14.039 |      1.441 | 0.000 |        0.001 | True           |
+| generated_tree_reuse       | `b57daa400252` |      12.385 | 1.140 |       1.366 |      6.658 | 1.536 |        0.000 | True           |
+| generated_tree_reuse       | `f1aa103ccd7c` |       0.117 | 0.527 |       2.218 |      3.448 | 0.000 |        0.000 | True           |
+| mixed_all                  | `400c2bebfdf7` |       0.105 | 0.257 |       5.214 |     12.572 | 0.000 |        0.001 | True           |
+| nested_individual_files    | `00a5c8fd5eca` |       0.134 | 0.265 |      12.860 |      5.493 | 0.000 |        0.000 | True           |
+| nested_individual_files    | `06648fa82c90` |       5.043 | 0.253 |       1.228 |      3.685 | 0.000 |        0.001 | True           |
+| nested_individual_files    | `0e936d2585e1` |       0.114 | 0.220 |      18.704 |      1.623 | 0.000 |        0.000 | True           |
+| nested_individual_files    | `38e0080a81a7` |       0.115 | 0.208 |      15.868 |      1.725 | 0.000 |        0.001 | True           |
+| nested_individual_files    | `6e61d7c5c043` |       0.114 | 0.213 |       1.572 |      2.024 | 0.000 |        0.001 | True           |
+| nested_individual_files    | `7bb6083de2c1` |       0.278 | 0.251 |       3.609 |      2.952 | 0.000 |        0.000 | True           |
+| nested_individual_files    | `7ebc5b535734` |       0.667 | 0.341 |      11.347 |      4.417 | 0.000 |        0.000 | True           |
+| nested_individual_files    | `a455f1d89ad8` |       0.110 | 0.263 |       1.580 |      2.236 | 0.000 |        0.000 | True           |
+| pids_one_regression        | `bbe16c49ab86` |       0.122 | 0.307 |       6.946 |      1.084 | 0.000 |        0.001 | True           |
+| source_dir_tree            | `35ad590c3e20` |       6.631 | 0.303 |       2.926 |      0.600 | 0.000 |        0.000 | True           |
+| source_dir_tree            | `94ef482d0fd5` |       7.094 | 0.854 |       4.140 |      4.930 | 0.000 |        0.000 | True           |
+| source_dir_tree            | `98458d72ec38` |       6.144 | 0.752 |       1.308 |      7.867 | 0.000 |        0.000 | True           |
+| source_dir_tree            | `f176f6534568` |       6.808 | 0.417 |       2.355 |      7.892 | 5.675 |        0.000 | True           |
+| symlink_input_consumer     | `e7ebd25b87b9` |       0.109 | 0.193 |       1.058 |      0.857 | 0.000 |        0.000 | True           |
+| timeout_recovery           | `ed01de57e2a7` |       0.288 | 0.740 |      17.969 |      2.868 | 0.000 |        0.001 | True           |
 
 ## VM Bridge Timing
 
 These are raw TCP-to-vsock pump connection measurements logged by `darwin-actiond serve-vm`.
 
-- Bridge connections logged: `9`
-- Total client to guest bytes: `1.47 MiB`
+- Bridge connections logged: `6`
+- Total client to guest bytes: `1.43 MiB`
 - Total guest to client bytes: `0.30 MiB`
 - Pump errors: read=`0`, write=`0`
 
-| Bridge Metric          |     Min |     p25 |     p50 |     p75 |      p95 |     Mean |      Max |
-| ---------------------- | ------: | ------: | ------: | ------: | -------: | -------: | -------: |
-| connection elapsed     | 142.430 | 728.515 | 773.341 | 810.956 | 3337.637 | 1197.899 | 3512.199 |
-| client to guest KiB    |     2.5 |    19.7 |   126.2 |   172.2 |    503.7 |    167.1 |    705.4 |
-| guest to client KiB    |     0.9 |     2.3 |    37.6 |    43.9 |     81.1 |     34.3 |     96.5 |
-| client to guest reads  |      11 |      18 |     184 |     241 |      252 |    148.3 |      253 |
-| client to guest writes |      11 |      18 |     184 |     241 |      252 |    148.3 |      253 |
-| guest to client reads  |       9 |      21 |     106 |     128 |      136 |     85.4 |      138 |
-| guest to client writes |       9 |      21 |     106 |     128 |      136 |     85.4 |      138 |
+| Bridge Metric          |     Min |     p25 |      p50 |      p75 |      p95 |     Mean |      Max |
+| ---------------------- | ------: | ------: | -------: | -------: | -------: | -------: | -------: |
+| connection elapsed     | 155.124 | 309.787 | 1899.559 | 3321.879 | 4764.864 | 2128.014 | 5237.991 |
+| client to guest KiB    |     0.0 |     6.8 |     19.6 |    371.2 |    819.7 |    243.4 |    930.1 |
+| guest to client KiB    |     0.0 |     1.3 |      2.2 |     81.9 |    173.4 |     51.5 |    195.0 |
+| client to guest reads  |       1 |      10 |       14 |      260 |      399 |    133.0 |      418 |
+| client to guest writes |       1 |      10 |       14 |      260 |      399 |    133.0 |      418 |
+| guest to client reads  |       0 |      10 |       16 |      338 |      458 |    158.2 |      463 |
+| guest to client writes |       0 |      10 |       16 |      338 |      458 |    158.2 |      463 |
 
 ## Per Action
 
-| Stress Case                | Digest         |   Total | Input | Execute | Output | Bind Mounts |        Outputs |
-| -------------------------- | -------------- | ------: | ----: | ------: | -----: | ----------: | -------------: |
-| aggregate                  | `2fa3a4511718` |  26.055 | 0.285 |  25.686 |  0.083 |           4 |  1 file, 0 dir |
-| bare_individual_files      | `1a9a1d7d45e4` |  33.577 | 0.290 |  32.505 |  0.782 |           4 |  1 file, 1 dir |
-| bare_individual_files      | `293475ee06bb` |  30.751 | 0.340 |  30.257 |  0.154 |           4 |  1 file, 1 dir |
-| bare_individual_files      | `96c424f1edad` |  17.519 | 0.295 |  14.856 |  2.368 |           4 |  1 file, 1 dir |
-| bare_individual_files      | `ccdb7626dedd` |  34.415 | 5.781 |  28.500 |  0.134 |           4 |  1 file, 1 dir |
-| filesystem_regression      | `9a580d312f78` | 284.074 | 0.308 | 281.650 |  2.116 |           4 |  1 file, 1 dir |
-| generated_file_producer    | `174bffc360c9` |  34.346 | 0.645 |  26.347 |  7.354 |           4 | 97 file, 0 dir |
-| generated_individual_files | `2d4ce7a45898` |  41.087 | 0.715 |  38.235 |  2.136 |           4 |  1 file, 1 dir |
-| generated_individual_files | `58d933f8a1cc` |  59.443 | 7.604 |  51.703 |  0.137 |           4 |  1 file, 1 dir |
-| generated_individual_files | `ebe0486999bc` |  19.589 | 0.402 |  18.708 |  0.478 |           4 |  1 file, 1 dir |
-| generated_individual_files | `ef34017f746a` |  37.145 | 0.321 |  35.265 |  1.559 |           4 |  1 file, 1 dir |
-| generated_tree_producer    | `db960becfd36` |  44.460 | 1.335 |  32.007 | 11.117 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `056bce18df22` |  37.129 | 0.804 |  34.458 |  1.867 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `1c8778f3cc78` |   9.727 | 0.506 |   8.142 |  1.078 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `21983588efc6` |  54.266 | 2.430 |  51.738 |  0.098 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `46d362087f03` |  37.448 | 0.284 |  34.119 |  3.045 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `5eba25364668` |  14.213 | 0.277 |  13.823 |  0.113 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `94a4a5794423` |  15.725 | 1.360 |  14.238 |  0.127 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `e89401eb9021` |  55.707 | 0.279 |  38.448 | 16.980 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `f433d0b3a994` |  13.349 | 0.803 |  12.424 |  0.122 |           4 |  1 file, 1 dir |
-| mixed_all                  | `c91e0b696fc8` |  20.897 | 0.271 |  17.814 |  2.812 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `3dff464548c3` |  39.318 | 0.306 |  37.921 |  1.092 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `624772a8ae88` |  15.882 | 0.273 |  14.809 |  0.800 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `6875f2d910c8` |  57.129 | 0.315 |  36.228 | 20.587 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `7c722534d2c8` |  26.195 | 0.354 |  24.169 |  1.673 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `b77221109b6c` |  33.105 | 2.097 |  30.510 |  0.499 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `c66b33449ee8` |  26.067 | 0.318 |  24.554 |  1.196 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `e9b5b4f432a6` |  57.012 | 0.318 |  41.575 | 15.118 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `f904af8dd963` |  32.356 | 0.689 |  31.209 |  0.458 |           4 |  1 file, 1 dir |
-| pids_one_regression        | `cd3cb4b17ba0` |  13.369 | 0.305 |  12.916 |  0.148 |           4 |  1 file, 1 dir |
-| source_dir_tree            | `0744164ec172` |  23.930 | 0.619 |  23.008 |  0.302 |           4 |  1 file, 1 dir |
-| source_dir_tree            | `25d07a1a15b9` |  24.043 | 0.467 |  22.706 |  0.869 |           4 |  1 file, 1 dir |
-| source_dir_tree            | `5d07305214c6` |  22.636 | 0.354 |  21.831 |  0.451 |           4 |  1 file, 1 dir |
-| source_dir_tree            | `c7d0b3212bf8` |  39.748 | 0.619 |  39.009 |  0.120 |           4 |  1 file, 1 dir |
-| symlink_input_consumer     | `5c31db5029b1` |   4.168 | 0.272 |   3.484 |  0.412 |           4 |  1 file, 1 dir |
-| timeout_recovery           | `01ac7dd6dd9b` |  27.716 | 3.338 |  23.844 |  0.533 |           4 |  1 file, 1 dir |
+| Stress Case                | Digest         |  Total | Input | Execute | Output | Bind Mounts |        Outputs |
+| -------------------------- | -------------- | -----: | ----: | ------: | -----: | ----------: | -------------: |
+| aggregate                  | `1aaef86306e4` | 21.765 | 0.334 |  21.358 |  0.073 |           4 |  1 file, 0 dir |
+| bare_individual_files      | `066472414ea9` | 14.869 | 0.315 |  14.297 |  0.257 |           4 |  1 file, 1 dir |
+| bare_individual_files      | `2bf32e1a816e` | 16.192 | 0.318 |  15.431 |  0.443 |           4 |  1 file, 1 dir |
+| bare_individual_files      | `5f0c7908f803` | 27.436 | 0.297 |  26.984 |  0.155 |           4 |  1 file, 1 dir |
+| bare_individual_files      | `9ddf9d0661e8` | 12.000 | 0.304 |  11.042 |  0.654 |           4 |  1 file, 1 dir |
+| filesystem_regression      | `a889da71fec5` | 96.064 | 0.403 |  94.466 |  1.194 |           4 |  1 file, 1 dir |
+| generated_file_producer    | `ce0a87dadeaf` | 40.791 | 0.729 |  34.097 |  5.964 |           4 | 97 file, 0 dir |
+| generated_individual_files | `07134f6f78fb` | 15.735 | 0.774 |  14.543 |  0.418 |           4 |  1 file, 1 dir |
+| generated_individual_files | `1ada216cf349` |  5.755 | 0.441 |   4.240 |  1.074 |           4 |  1 file, 1 dir |
+| generated_individual_files | `2fcd9276e686` |  4.954 | 0.290 |   4.410 |  0.254 |           4 |  1 file, 1 dir |
+| generated_individual_files | `963770016a83` |  4.176 | 0.574 |   3.459 |  0.142 |           4 |  1 file, 1 dir |
+| generated_tree_producer    | `a0e22e4a2449` | 54.918 | 0.265 |  44.202 | 10.451 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `234fe92db0c4` | 15.071 | 0.334 |  14.546 |  0.190 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `307f8dd32223` | 11.144 | 0.294 |  10.549 |  0.302 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `31ecae29e592` |  7.819 | 0.359 |   7.343 |  0.117 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `3a94355a7850` |  3.893 | 0.305 |   3.454 |  0.134 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `3f5910cbd10a` |  4.308 | 0.303 |   3.867 |  0.138 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `958cf2efa665` | 18.433 | 0.366 |  15.942 |  2.125 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `b57daa400252` | 23.601 | 0.311 |  23.120 |  0.169 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `f1aa103ccd7c` |  7.096 | 0.358 |   6.325 |  0.413 |           4 |  1 file, 1 dir |
+| mixed_all                  | `400c2bebfdf7` | 21.317 | 0.309 |  18.169 |  2.839 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `00a5c8fd5eca` | 24.818 | 0.621 |  18.774 |  5.422 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `06648fa82c90` | 11.444 | 0.308 |  10.241 |  0.895 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `0e936d2585e1` | 21.472 | 0.301 |  20.683 |  0.487 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `38e0080a81a7` | 18.718 | 0.305 |  17.978 |  0.435 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `6e61d7c5c043` |  5.278 | 0.308 |   3.945 |  1.024 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `7bb6083de2c1` |  7.843 | 0.321 |   7.106 |  0.416 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `7ebc5b535734` | 18.108 | 0.378 |  16.809 |  0.921 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `a455f1d89ad8` |  5.058 | 0.367 |   4.213 |  0.478 |           4 |  1 file, 1 dir |
+| pids_one_regression        | `bbe16c49ab86` |  8.981 | 0.328 |   8.493 |  0.160 |           4 |  1 file, 1 dir |
+| source_dir_tree            | `35ad590c3e20` | 11.335 | 0.359 |  10.503 |  0.472 |           4 |  1 file, 1 dir |
+| source_dir_tree            | `94ef482d0fd5` | 17.458 | 0.291 |  17.037 |  0.129 |           4 |  1 file, 1 dir |
+| source_dir_tree            | `98458d72ec38` | 16.579 | 0.287 |  16.085 |  0.207 |           4 |  1 file, 1 dir |
+| source_dir_tree            | `f176f6534568` | 25.419 | 0.715 |  23.182 |  1.522 |           4 |  1 file, 1 dir |
+| symlink_input_consumer     | `e7ebd25b87b9` |  2.800 | 0.287 |   2.239 |  0.274 |           4 |  1 file, 1 dir |
+| timeout_recovery           | `ed01de57e2a7` | 22.876 | 0.683 |  21.918 |  0.275 |           4 |  1 file, 1 dir |
 
 ## Notes
 

--- a/tools/e2e_action_tool.zig
+++ b/tools/e2e_action_tool.zig
@@ -929,6 +929,27 @@ fn exerciseFileMetadata(io: std.Io, dir: std.Io.Dir) !void {
         }
     }
 
+    {
+        var populated = try dir.createFile(io, "truncate-open.txt", .{ .read = true });
+        try populated.writeStreamingAll(io, "nonempty staged file");
+        populated.close(io);
+
+        var truncated = try dir.createFile(io, "truncate-open.txt", .{
+            .read = true,
+            .truncate = true,
+        });
+        defer truncated.close(io);
+        try requireFilesystem(
+            (try truncated.stat(io)).size == 0,
+            "staged O_TRUNC open did not clear the open file size",
+        );
+        try requireFilesystem(
+            (try dir.statFile(io, "truncate-open.txt", .{})).size == 0,
+            "staged O_TRUNC open did not clear the directory entry size",
+        );
+    }
+    try dir.deleteFile(io, "truncate-open.txt");
+
     var second = try dir.openFile(io, "payload.txt", .{ .mode = .read_write });
     defer second.close(io);
     try file.setLength(io, 3);

--- a/tools/e2e_action_tool.zig
+++ b/tools/e2e_action_tool.zig
@@ -877,6 +877,21 @@ fn exerciseFileMetadata(io: std.Io, dir: std.Io.Dir) !void {
                 .SUCCESS => return filesystemFailure("unprivileged staged fchown unexpectedly succeeded"),
                 else => return filesystemFailure("unprivileged staged fchown returned an unexpected errno"),
             }
+
+            switch (std.os.linux.errno(linux.fchmod(file.handle, 0o6755))) {
+                .SUCCESS => {},
+                else => return filesystemFailure("staged setuid/setgid chmod failed"),
+            }
+            try requireFilesystem(
+                ((try file.stat(io)).permissions.toMode() & 0o6000) == 0o6000,
+                "staged chmod did not expose setuid/setgid permissions",
+            );
+            try file.setLength(io, payload.len);
+            try requireFilesystem(
+                ((try file.stat(io)).permissions.toMode() & 0o6000) == 0,
+                "staged truncate did not clear setuid/setgid permissions",
+            );
+            try file.setPermissions(io, std.Io.File.Permissions.fromMode(0o640));
         }
     }
 

--- a/tools/e2e_action_tool.zig
+++ b/tools/e2e_action_tool.zig
@@ -881,7 +881,7 @@ fn exerciseFileMetadata(io: std.Io, dir: std.Io.Dir) !void {
             {
                 var privileged = try dir.createFile(io, "privileged-create.txt", .{
                     .read = true,
-                    .permissions = std.Io.File.Permissions.fromMode(0o6755),
+                    .permissions = std.Io.File.Permissions.fromMode(0o6744),
                 });
                 defer privileged.close(io);
                 try requireFilesystem(

--- a/tools/e2e_action_tool.zig
+++ b/tools/e2e_action_tool.zig
@@ -878,6 +878,19 @@ fn exerciseFileMetadata(io: std.Io, dir: std.Io.Dir) !void {
                 else => return filesystemFailure("unprivileged staged fchown returned an unexpected errno"),
             }
 
+            {
+                var privileged = try dir.createFile(io, "privileged-create.txt", .{
+                    .read = true,
+                    .permissions = std.Io.File.Permissions.fromMode(0o6755),
+                });
+                defer privileged.close(io);
+                try requireFilesystem(
+                    ((try privileged.stat(io)).permissions.toMode() & 0o6000) == 0o6000,
+                    "staged create did not preserve setuid/setgid permissions",
+                );
+            }
+            try dir.deleteFile(io, "privileged-create.txt");
+
             switch (std.os.linux.errno(linux.fchmod(file.handle, 0o6755))) {
                 .SUCCESS => {},
                 else => return filesystemFailure("staged setuid/setgid chmod failed"),

--- a/tools/e2e_action_tool.zig
+++ b/tools/e2e_action_tool.zig
@@ -892,6 +892,40 @@ fn exerciseFileMetadata(io: std.Io, dir: std.Io.Dir) !void {
                 "staged truncate did not clear setuid/setgid permissions",
             );
             try file.setPermissions(io, std.Io.File.Permissions.fromMode(0o640));
+
+            {
+                var destination = try dir.createFile(io, "privileged-copy.txt", .{ .read = true });
+                defer destination.close(io);
+                switch (std.os.linux.errno(linux.fchmod(destination.handle, 0o6755))) {
+                    .SUCCESS => {},
+                    else => return filesystemFailure("staged copy destination setuid/setgid chmod failed"),
+                }
+                try requireFilesystem(
+                    ((try destination.stat(io)).permissions.toMode() & 0o6000) == 0o6000,
+                    "staged copy destination did not expose setuid/setgid permissions",
+                );
+
+                var source_offset: i64 = 0;
+                var destination_offset: i64 = 0;
+                const copied = linux.copy_file_range(
+                    file.handle,
+                    &source_offset,
+                    destination.handle,
+                    &destination_offset,
+                    1,
+                    0,
+                );
+                switch (linux.errno(copied)) {
+                    .SUCCESS => {},
+                    else => return filesystemFailure("staged copy_file_range failed"),
+                }
+                try requireFilesystem(copied == 1, "staged copy_file_range copied an unexpected byte count");
+                try requireFilesystem(
+                    ((try destination.stat(io)).permissions.toMode() & 0o6000) == 0,
+                    "staged copy_file_range did not clear setuid/setgid permissions",
+                );
+            }
+            try dir.deleteFile(io, "privileged-copy.txt");
         }
     }
 


### PR DESCRIPTION
Continue merged #26 with 30 separately reviewable actiondfs commits.

Prevent unprivileged staged operations from triggering the Linux notify_change BUG on privilege removal; serialize staged writes and copy_file_range, preserve and correctly clear setuid/setgid bits, honor backing mount idmaps, reject malformed protobuf keys, and sanitize forwarded ATTR_OPEN. Simplify staged dentry publication, inode classification and ownership, CAS and staged path references, cached-child allocation, generation locking, and protobuf fixed-width decoding. The actiondfs implementation removes 28 net lines and adds focused VM regressions for non-root privileged-file creation, truncation, copy_file_range, and O_TRUNC.

Validation: all 66 supported cross-architecture Bazel build targets and repository tests; standalone timing-parser test; production and instrumented macOS Virtualization.framework VM suites; fresh LLVM VM smoke with 2,017 warmup and 2,106 measured actions; all five GitHub Actions checks passed. Matched 1,998-action CI benchmarks: Linux actiond 304.743s / native 313.029s = 0.974x versus main 1.055x; Windows actiond 348.083s / native 373.566s = 0.932x versus main 1.005x. Both VM timing reports are refreshed.