### PR TITLE
actiondfs: reduce filesystem overhead and prevent sandbox escapes

### DIFF
--- a/e2e/LLVM_VM_SMOKE_TIMINGS.md
+++ b/e2e/LLVM_VM_SMOKE_TIMINGS.md
@@ -27,21 +27,21 @@ subset of the VM `llvm-tblgen` graph.
 
 ## Latest Checked-In Result
 
-- Generated: `2026-08-01 15:44:38 EDT`
+- Generated: `2026-08-01 18:24:59 EDT`
 - Command: `ACTIOND_BAZEL_BUILD_FLAGS="--jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" ACTIOND_LLVM_SMOKE_MAC_HOST=0 e2e/run_llvm_vm_smoke.sh`
-- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.yu77B2`
+- Output root: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-llvm-vm-smoke.G6vg1w`
 - Workload: `@llvm-project//llvm:llvm-tblgen`, jobs=8
 - VM warmup target: `//e2e:llvm_exec_warmup`
 - Target and VM host platform: `@llvm//platforms:linux_arm64_musl`
 - Build mode: `-c opt --strip=always --stripopt=--strip-all`
-- VM warmup: `82.129s`; `2207 processes: 190 internal, 2017 remote`
-- Measured VM build: `92.336s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
+- VM warmup: `90.262s`; `2207 processes: 190 internal, 2017 remote`
+- Measured VM build: `98.569s`; `2310 processes: 4 action cache hit, 204 internal, 2106 remote`
 - Measured executions and timing records: `2106`
 - Mac-host baseline: not run (`ACTIOND_LLVM_SMOKE_MAC_HOST=0`)
 
 The previous checked-in run used the same jobs=8 and completed the warmup in
-`83.160s` and measured build in `88.494s`. The current measured build is 4.3%
-slower with the same 2,106 actions, while its warmup is 1.2% faster with the
+`82.129s` and measured build in `92.336s`. The current measured build is 6.8%
+slower with the same 2,106 actions, while its warmup is 9.9% slower with the
 same 2,017 actions. A repeat with the previous code completed the warmup in
 `63.992s` and the measured build in `86.002s`. Intermediate runs on the same
 machine completed the warmup/measured builds in `96.032s`/`104.393s` and
@@ -63,9 +63,12 @@ Counters include both warmup and measured builds.
 | ------------------------------------ | ----------: | ----------: |
 | actiondfs mounts                     |       4,122 |       4,122 |
 | root directory parses                |       1,405 |       1,405 |
-| cached directory hits                |     163,011 |     162,998 |
-| cached directory misses              |       6,606 |       6,619 |
-| directory blob reads                 |       6,605 |       6,618 |
+| directory loads                      |     151,235 |     169,617 |
+| cached directory requests            |     169,617 |     169,617 |
+| cached directory hits                |     162,998 |     163,010 |
+| cached directory misses              |       6,619 |       6,607 |
+| cached directory races               |          13 |           1 |
+| directory blob reads                 |       6,618 |       6,606 |
 | staged ensure-directory calls        |      15,996 |      15,996 |
 | staged ensure-directory components   |          16 |          16 |
 | staged ensure-directory existing     |           0 |           0 |
@@ -76,19 +79,29 @@ Counters include both warmup and measured builds.
 | blob-path cache evictions            |           0 |           0 |
 | blob-path cache insertion races      |           0 |           0 |
 | staged backing open attempts         |      15,825 |      15,825 |
-| staged backing open lookup           | 0.705 ms    | 0.297 ms    |
+| staged backing open lookup           | 0.297 ms    | 0.324 ms    |
 | staged `copy_file_range` successes   |       3,828 |       3,828 |
 | staged `copy_file_range` fallbacks   |           0 |           0 |
 
 The workload retained the same 2,017 warmup actions and 2,106 measured actions.
-All 162,998 cached-directory hits used RCU instead of the global directory-cache
+All 163,010 cached-directory hits used RCU instead of the global directory-cache
 mutex, and all 18,382 staged input-directory merges searched only cached input
-directories. Root inode ownership reduced each of the 4,122 superblock
-allocations from 128 bytes to 96 bytes, and unhashed root inodes avoided global
-inode-hash insertion on each mount. CAS blob lookups and staged parent lookups
-borrowed existing mount or path references. Root-directory parsing, staged
-parent-directory reuse, and blob-path cache behavior remain close to the previous
-checked-in result.
+directories. The 169,617 cached-directory requests were unchanged: merged input
+directories deferred metadata loading until first access instead of removing
+directory-cache requests. The 472,190 input backing-file acquisitions used RCU,
+and 75,358 staged positive or negative inode lookups avoided exclusive backing
+directory locks. Resolving 6,883 CAS cache misses and 6,606 directory blobs
+directly avoided 13,489 temporary `PATH_MAX` pathname allocations, or about
+52.7 MiB of cumulative allocation. Root inode ownership reduced each of the
+4,122 superblock allocations from 128 bytes to 96 bytes, and unhashed root
+inodes avoided global inode-hash insertion on each mount.
+
+Staged inode ownership followed the backing inode through the staged mount
+idmap, preserving sandbox uid and gid checks. Unsupported extended attributes
+were skipped without bypassing normal inode permission checks, and backing
+filesystem security flags were inherited only when the backing filesystem
+advertised the same guarantees. Staged create, mkdir, unlink, rename, size
+updates, mmap, and child lookups reported zero failures.
 
 ## VM Stage Timing
 
@@ -96,10 +109,10 @@ All timing values are milliseconds.
 
 | Stage                 |   Min |    p25 |    p50 |     p75 |      p95 |    Mean |       Max |
 | --------------------- | ----: | -----: | -----: | ------: | -------: | ------: | --------: |
-| total                 | 7.303 | 22.280 | 31.502 |  72.387 | 1654.434 | 304.721 |  9170.784 |
-| input fetch/setup     | 0.405 |  0.586 |  0.642 |   0.996 |    1.994 |   1.034 |    60.478 |
-| execute               | 5.979 | 20.755 | 29.458 |  71.567 | 1651.500 | 302.320 |  9161.111 |
-| output upload/collect | 0.022 |  0.138 |  0.262 |   1.601 |    5.233 |   1.367 |   157.599 |
+| total                 | 7.179 | 24.020 | 34.068 |  93.793 | 1725.016 | 315.365 | 11505.363 |
+| input fetch/setup     | 0.400 |  0.582 |  0.668 |   1.053 |    2.103 |   1.269 |    84.561 |
+| execute               | 6.238 | 22.263 | 31.895 |  91.312 | 1722.654 | 312.755 | 11499.724 |
+| output upload/collect | 0.026 |  0.136 |  0.258 |   1.312 |    5.180 |   1.341 |   121.919 |
 
 ## Runner Timing
 
@@ -109,12 +122,12 @@ and lazy actiondfs input reads. All timing values are milliseconds.
 
 | Runner Stage   |   Min |    p25 |    p50 |    p75 |      p95 |    Mean |       Max |
 | -------------- | ----: | -----: | -----: | -----: | -------: | ------: | --------: |
-| parent prepare | 0.049 |  0.100 |  0.124 |  0.154 |    0.395 |   0.193 |    12.384 |
-| fork           | 0.252 |  0.505 |  0.576 |  1.042 |    5.887 |   1.766 |   201.901 |
-| child setup    | 0.004 |  1.761 |  3.161 |  6.020 |   21.088 |   6.044 |   107.745 |
-| process/io     | 0.588 | 15.747 | 22.252 | 52.498 | 1646.214 | 293.593 |  9134.104 |
-| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    4.334 |   0.575 |    14.531 |
-| stdio digest   | 0.000 |  0.001 |  0.001 |  0.001 |    0.001 |   0.001 |     0.142 |
+| parent prepare | 0.057 |  0.105 |  0.135 |  0.199 |    0.412 |   0.280 |    55.961 |
+| fork           | 0.438 |  0.723 |  0.819 |  1.902 |    7.894 |   2.690 |   143.889 |
+| child setup    | 0.004 |  2.816 |  4.654 |  8.657 |   30.668 |   9.209 |   220.184 |
+| process/io     | 0.002 | 15.844 | 23.161 | 64.357 | 1716.234 | 299.968 | 11479.045 |
+| wait           | 0.000 |  0.000 |  0.000 |  0.000 |    3.570 |   0.385 |    23.227 |
+| stdio digest   | 0.000 |  0.000 |  0.001 |  0.001 |    0.001 |   0.001 |     0.135 |
 
 ## actiondfs Counters
 
@@ -124,13 +137,16 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 | ----------------------------- | --------------: |
 | mounts                        |           4,122 |
 | root directory parses         |           1,405 |
+| directory loads               |         169,617 |
 | cached directory requests     |         169,617 |
-| cached directory hits         |         162,998 |
-| cached directory misses       |           6,619 |
+| cached directory hits         |         163,010 |
+| cached directory misses       |           6,607 |
+| cached directory races        |               1 |
 | lookups                       |       1,406,668 |
 | lookup hits                   |         841,778 |
 | lookup negative               |         564,890 |
-| blob open attempts            |         474,193 |
+| blob open attempts            |         474,181 |
+| blob open stale retries       |               0 |
 | blob-path cache hits          |         460,692 |
 | blob-path cache misses        |           6,883 |
 | blob-path cache evictions     |               0 |
@@ -139,11 +155,12 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 | node blob cache misses        |         467,575 |
 | backing reads                 |         415,332 |
 | backing read bytes            |   1,303,012,282 |
+| backing read stale retries    |               0 |
 | mmap calls                    |          53,030 |
 | mmap bytes                    | 1,900,832,624,640 |
 | mmap failures                 |               0 |
-| directory blob reads          |           6,618 |
-| directory blob bytes          |       2,732,839 |
+| directory blob reads          |           6,606 |
+| directory blob bytes          |       2,720,139 |
 
 ## Staged Filesystem Counters
 
@@ -154,27 +171,41 @@ These `/proc/actiondfs_stats` counters cover the VM lifetime.
 | staged ensure-directory existing     |           0 |
 | staged ensure-directory created      |          16 |
 | staged parent dentry hits            |      15,980 |
+| staged child lookups                 |      87,568 |
+| staged child lookup hits             |      35,533 |
+| staged child lookup negative         |      52,035 |
+| staged child lookup failures         |           0 |
 | staged inode lookups                 |   1,406,668 |
-| staged inode unstaged-parent skips   |   1,331,308 |
+| staged inode unstaged-parent skips   |   1,331,310 |
 | staged inode lookup hits             |      35,518 |
-| staged inode lookup negative         |      39,842 |
+| staged inode lookup negative         |      39,840 |
+| staged inode lookup failures         |           0 |
 | staged inode input-directory merges  |      18,382 |
 | staged backing open attempts         |      15,825 |
 | staged backing open failures         |           0 |
-| staged backing open total            |   12.784 ms |
-| staged backing open lookup           |    0.297 ms |
-| staged backing open file             |   10.582 ms |
+| staged backing open total            |   12.790 ms |
+| staged backing open lookup           |    0.324 ms |
+| staged backing open file             |   10.718 ms |
 | staged create calls/successes        |      11,981 |
+| staged create failures               |           0 |
 | staged mkdir calls/successes         |         198 |
+| staged mkdir failures                |           0 |
+| staged unlink calls/successes        |          15 |
+| staged unlink failures               |           0 |
 | staged rename calls/successes        |       3,817 |
+| staged rename failures               |           0 |
 | staged size updates/successes        |       3,874 |
-| staged write calls                   |      37,140 |
-| staged write bytes                   | 106,132,435 |
+| staged size update failures          |           0 |
+| staged write calls                   |      37,065 |
+| staged write bytes                   | 105,766,927 |
+| staged mmap calls                    |          30 |
+| staged mmap bytes                    |   2,084,864 |
+| staged mmap failures                 |           0 |
 | staged `copy_file_range` successes   |       3,828 |
 | staged `copy_file_range` bytes       |  31,630,764 |
 | staged `copy_file_range` fallbacks   |           0 |
 
-The staged-negative filter skipped 1,331,308 lookups with known-unstaged
+The staged-negative filter skipped 1,331,310 lookups with known-unstaged
 parents. All 3,828 `copy_file_range` attempts succeeded without a buffered
 fallback.
 
@@ -186,10 +217,10 @@ fallback.
 | CAS promotion attempts               |      7,947 |
 | CAS promotion success                |      2,087 |
 | CAS existing-blob hits               |      5,860 |
-| CAS promoted bytes                   | 32,082,447 |
-| CAS digest bytes                     | 84,416,399 |
-| CAS promotion digest                 | 642.254 ms |
-| CAS promotion rename                 | 127.801 ms |
+| CAS promoted bytes                   | 31,718,871 |
+| CAS digest bytes                     | 84,052,823 |
+| CAS promotion digest                 | 661.226 ms |
+| CAS promotion rename                 | 174.472 ms |
 | CAS cross-device fallbacks           |          0 |
 | CAS permission fallbacks             |          0 |
 | CAS put-file copy calls              |          0 |
@@ -199,7 +230,7 @@ fallback.
 | Counter                              |      Value |
 | ------------------------------------ | ---------: |
 | ByteStream file reads                |      4,038 |
-| ByteStream file bytes                | 57,616,538 |
+| ByteStream file bytes                | 57,614,606 |
 | ByteStream buffered reads            |          0 |
 | gRPC response tasks started          |     36,229 |
 | gRPC response tasks failed           |          0 |
@@ -207,10 +238,10 @@ fallback.
 | gRPC data frames                     |     37,011 |
 | gRPC file payload frames             |      6,902 |
 | gRPC `sendfile` attempts/successes   |      6,902 |
-| gRPC `sendfile` bytes                | 57,616,538 |
+| gRPC `sendfile` bytes                | 57,614,606 |
 | gRPC `sendfile` fallbacks            |          0 |
 
-The measured TCP-to-vsock bridge logged two connections, 28.25 MiB from client
-to guest, 37.36 MiB from guest to client, and zero read/write pump errors.
+The measured TCP-to-vsock bridge logged two connections, 28.15 MiB from client
+to guest, 37.37 MiB from guest to client, and zero read/write pump errors.
 ByteStream reads remained file-backed and all 6,902 gRPC `sendfile` attempts
 succeeded.

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -3099,21 +3099,12 @@ static int actiondfs_emit_stage_entries(struct inode *inode,
 	return 0;
 }
 
-static int actiondfs_dir_open(struct inode *inode, struct file *file)
-{
-	struct actiondfs_dir_file *dir_file;
-
-	dir_file = kzalloc(sizeof(*dir_file), GFP_KERNEL);
-	if (!dir_file)
-		return -ENOMEM;
-	file->private_data = dir_file;
-	return 0;
-}
-
 static int actiondfs_dir_release(struct inode *inode, struct file *file)
 {
 	struct actiondfs_dir_file *dir_file = file->private_data;
 
+	if (!dir_file)
+		return 0;
 	if (dir_file->stage_file)
 		fput(dir_file->stage_file);
 	kfree(dir_file);
@@ -3155,6 +3146,19 @@ static int actiondfs_iterate_shared(struct file *file, struct dir_context *ctx)
 	struct actiondfs_dir_file *dir_file = file->private_data;
 	loff_t base = 2;
 	int err;
+
+	if (!dir_file) {
+		struct actiondfs_dir_file *existing;
+
+		dir_file = kzalloc(sizeof(*dir_file), GFP_KERNEL);
+		if (!dir_file)
+			return -ENOMEM;
+		existing = cmpxchg(&file->private_data, NULL, dir_file);
+		if (existing) {
+			kfree(dir_file);
+			dir_file = existing;
+		}
+	}
 
 	if (!ctx->pos && (dir_file->stage_file || dir_file->stage_eof))
 		actiondfs_reset_stage_file(dir_file);
@@ -3268,7 +3272,6 @@ static const struct inode_operations actiondfs_dir_iops = {
 };
 
 static const struct file_operations actiondfs_dir_fops = {
-	.open = actiondfs_dir_open,
 	.release = actiondfs_dir_release,
 	.fsync = actiondfs_fsync,
 	.llseek = generic_file_llseek,

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -413,6 +413,18 @@ static struct actiondfs_sb_info *actiondfs_sbi(struct super_block *sb)
 	return sb->s_fs_info;
 }
 
+static void actiondfs_copy_stage_owner(struct inode *inode,
+				      struct inode *real_inode)
+{
+	struct mnt_idmap *idmap =
+		mnt_idmap(actiondfs_sbi(inode->i_sb)->stage_path.mnt);
+
+	spin_lock(&inode->i_lock);
+	inode->i_uid = vfsuid_into_kuid(i_uid_into_vfsuid(idmap, real_inode));
+	inode->i_gid = vfsgid_into_kgid(i_gid_into_vfsgid(idmap, real_inode));
+	spin_unlock(&inode->i_lock);
+}
+
 static void actiondfs_free_node(struct actiondfs_node *node)
 {
 	if (!node)
@@ -2229,6 +2241,8 @@ static void actiondfs_init_inode(struct inode *inode,
 {
 	inode->i_ino = node->ino;
 	inode_init_owner(&nop_mnt_idmap, inode, NULL, node->mode);
+	if (node->stage_dentry)
+		actiondfs_copy_stage_owner(inode, d_inode(node->stage_dentry));
 	inode_has_no_xattr(inode);
 	inode->i_private = node;
 	simple_inode_init_ts(inode);
@@ -2316,6 +2330,7 @@ static void actiondfs_insert_staged_inode(struct inode *inode,
 	node->stage_dentry = real_dentry;
 	inode->i_ino = node->ino;
 	inode->i_mode = node->mode;
+	actiondfs_copy_stage_owner(inode, real_inode);
 	insert_inode_hash(inode);
 }
 
@@ -2431,6 +2446,7 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	}
 	if (inode->i_private != node) {
 		node = inode->i_private;
+		actiondfs_copy_stage_owner(inode, real_inode);
 		actiondfs_set_stage_dentry(node, real_dentry);
 	}
 	if (S_ISDIR(mode)) {

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2326,7 +2326,6 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 {
 	struct actiondfs_sb_info *sbi = actiondfs_sbi(dir->i_sb);
 	struct actiondfs_cached_child *input_child = NULL;
-	struct actiondfs_cached_dir *input_cached = NULL;
 	struct path parent_path;
 	struct dentry *real_dentry;
 	struct inode *real_inode;
@@ -2356,13 +2355,6 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 			input_child = actiondfs_find_cached_child_in(
 				&parent->cached_dir->dirs, dentry->d_name.name,
 				dentry->d_name.len);
-		if (input_child) {
-			err = actiondfs_get_cached_dir(sbi, input_child->hash,
-						       input_child->size,
-						       &input_cached);
-			if (err)
-				goto out_error;
-		}
 	} else if (S_ISREG(mode)) {
 		mode = S_IFREG | (mode & S_IALLUGO);
 		size = i_size_read(real_inode);
@@ -2376,7 +2368,7 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 		goto out_negative;
 	}
 
-	if (input_cached) {
+	if (input_child) {
 		node = actiondfs_materialize_cached_child(parent, input_child);
 		if (IS_ERR(node)) {
 			err = PTR_ERR(node);
@@ -2415,10 +2407,8 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 
 out_unlock:
 	actiondfs_stage_unlock_child(&parent_path, real_dentry);
-	if (inode && !IS_ERR(inode) && input_cached) {
-		smp_store_release(&node->cached_dir, input_cached);
+	if (inode && !IS_ERR(inode) && input_child)
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_INPUT_DIR_MERGES);
-	}
 	return inode;
 
 out_negative:

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -419,10 +419,8 @@ static void actiondfs_copy_stage_owner(struct inode *inode,
 	struct mnt_idmap *idmap =
 		mnt_idmap(actiondfs_sbi(inode->i_sb)->stage_path.mnt);
 
-	spin_lock(&inode->i_lock);
 	inode->i_uid = vfsuid_into_kuid(i_uid_into_vfsuid(idmap, real_inode));
 	inode->i_gid = vfsgid_into_kgid(i_gid_into_vfsgid(idmap, real_inode));
-	spin_unlock(&inode->i_lock);
 }
 
 static void actiondfs_free_node(struct actiondfs_node *node)
@@ -2446,7 +2444,9 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	}
 	if (inode->i_private != node) {
 		node = inode->i_private;
+		spin_lock(&inode->i_lock);
 		actiondfs_copy_stage_owner(inode, real_inode);
+		spin_unlock(&inode->i_lock);
 		actiondfs_set_stage_dentry(node, real_dentry);
 	}
 	if (S_ISDIR(mode)) {

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1122,19 +1122,19 @@ retry:
 	return file;
 }
 
-static struct file *actiondfs_get_node_blob_file(struct actiondfs_node *node,
-						 struct file *actiondfs_file)
+static struct file *actiondfs_get_node_blob_file(struct file *actiondfs_file)
 {
+	struct file __rcu **slot =
+		(struct file __rcu **)&actiondfs_file->private_data;
 	struct file *file;
 
-	mutex_lock(&node->load_lock);
-	file = actiondfs_file->private_data;
-	if (file) {
-		get_file(file);
-		actiondfs_stat_inc(ACTIONDFS_STAT_NODE_BLOB_CACHE_HITS);
-	}
-	mutex_unlock(&node->load_lock);
-	return file ? file : ERR_PTR(-EBADF);
+	rcu_read_lock();
+	file = get_file_rcu(slot);
+	rcu_read_unlock();
+	if (!file)
+		return ERR_PTR(-EBADF);
+	actiondfs_stat_inc(ACTIONDFS_STAT_NODE_BLOB_CACHE_HITS);
+	return file;
 }
 
 static int actiondfs_reopen_node_blob_if_current(struct actiondfs_sb_info *sbi,
@@ -1154,7 +1154,9 @@ static int actiondfs_reopen_node_blob_if_current(struct actiondfs_sb_info *sbi,
 		if (IS_ERR(replacement)) {
 			err = PTR_ERR(replacement);
 		} else {
-			actiondfs_file->private_data = replacement;
+			rcu_assign_pointer(
+				*(struct file __rcu **)&actiondfs_file->private_data,
+				replacement);
 			fput(current_file);
 		}
 	}
@@ -1252,7 +1254,7 @@ static ssize_t actiondfs_read_iter(struct kiocb *iocb, struct iov_iter *to)
 	iov_iter_truncate(to, wanted);
 
 	do {
-		file = actiondfs_get_node_blob_file(node, iocb->ki_filp);
+		file = actiondfs_get_node_blob_file(iocb->ki_filp);
 		if (IS_ERR(file))
 			return PTR_ERR(file);
 
@@ -1369,7 +1371,7 @@ static ssize_t actiondfs_copy_file_range(struct file *file_in, loff_t pos_in,
 		goto out;
 	len = min_t(u64, (u64)len, node_in->size - pos_in);
 	if (node_in->origin == ACTIONDFS_NODE_INPUT) {
-		real_in = actiondfs_get_node_blob_file(node_in, file_in);
+		real_in = actiondfs_get_node_blob_file(file_in);
 	} else {
 		real_in = file_in->private_data;
 	}
@@ -1454,7 +1456,7 @@ static ssize_t actiondfs_splice_read(struct file *actiondfs_file, loff_t *ppos,
 	do {
 		struct kiocb backing_iocb;
 
-		file = actiondfs_get_node_blob_file(node, actiondfs_file);
+		file = actiondfs_get_node_blob_file(actiondfs_file);
 		if (IS_ERR(file))
 			return PTR_ERR(file);
 
@@ -1512,7 +1514,7 @@ static int actiondfs_mmap(struct file *actiondfs_file,
 		return err;
 	}
 
-	file = actiondfs_get_node_blob_file(node, actiondfs_file);
+	file = actiondfs_get_node_blob_file(actiondfs_file);
 	if (IS_ERR(file)) {
 		actiondfs_stat_inc(ACTIONDFS_STAT_MMAP_FAILURES);
 		return PTR_ERR(file);
@@ -2835,7 +2837,8 @@ static int actiondfs_open(struct inode *inode, struct file *file)
 	}
 	if (IS_ERR(backing_file))
 		return PTR_ERR(backing_file);
-	file->private_data = backing_file;
+	rcu_assign_pointer(*(struct file __rcu **)&file->private_data,
+			   backing_file);
 	return 0;
 }
 

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -61,7 +61,6 @@
 #define ACTIONDFS_BLOB_PATH_CACHE_MAX 16384
 #define ACTIONDFS_PROC_STATS "actiondfs_stats"
 #define ACTIONDFS_HASH_HEX_LEN 64
-#define ACTIONDFS_SHARDED_HASH_PATH_LEN (2 + 1 + ACTIONDFS_HASH_HEX_LEN)
 #define ACTIONDFS_EMPTY_SHA256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 #define ACTIONDFS_UNKNOWN_SIZE (~(u64)0)
 
@@ -988,15 +987,6 @@ static int actiondfs_valid_hash(const char *hash, size_t len)
 static bool actiondfs_is_empty_sha256(const char *hash)
 {
 	return !memcmp(hash, ACTIONDFS_EMPTY_SHA256, ACTIONDFS_HASH_HEX_LEN);
-}
-
-static void actiondfs_sharded_hash_path(const char *hash,
-					char out[ACTIONDFS_SHARDED_HASH_PATH_LEN + 1])
-{
-	memcpy(out, hash, 2);
-	out[2] = '/';
-	memcpy(out + 3, hash, ACTIONDFS_HASH_HEX_LEN);
-	out[ACTIONDFS_SHARDED_HASH_PATH_LEN] = '\0';
 }
 
 static bool actiondfs_retry_stale(int err, unsigned int *attempts)
@@ -1983,9 +1973,6 @@ static struct dentry *actiondfs_get_cached_blob_dentry(
 {
 	struct actiondfs_blob_path_cache_entry *entry;
 	struct dentry *dentry;
-	char path[ACTIONDFS_SHARDED_HASH_PATH_LEN + 1];
-	struct path real_path;
-	int err;
 
 	rcu_read_lock();
 	entry = actiondfs_find_blob_path_cache(sbi, hash);
@@ -1998,16 +1985,12 @@ static struct dentry *actiondfs_get_cached_blob_dentry(
 	rcu_read_unlock();
 
 	actiondfs_stat_inc(ACTIONDFS_STAT_BLOB_PATH_CACHE_MISSES);
-	actiondfs_sharded_hash_path(hash, path);
-	err = vfs_path_lookup(sbi->cas_path.dentry, sbi->cas_path.mnt,
-			      path, LOOKUP_FOLLOW | LOOKUP_NO_SYMLINKS |
-				    LOOKUP_NO_XDEV, &real_path);
-	if (err)
-		return ERR_PTR(err);
+	dentry = actiondfs_lookup_cas_blob(sbi, hash);
+	if (IS_ERR(dentry))
+		return dentry;
 
-	actiondfs_insert_blob_path_cache(sbi, hash, real_path.dentry);
-	mntput(real_path.mnt);
-	return real_path.dentry;
+	actiondfs_insert_blob_path_cache(sbi, hash, dentry);
+	return dentry;
 }
 
 static void actiondfs_drop_cached_blob_path(struct actiondfs_sb_info *sbi,

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -1022,33 +1022,77 @@ static bool actiondfs_retry_counted_stale(int err, unsigned int *attempts,
 	actiondfs_retry_stale((err), (attempts))
 #endif
 
+static struct dentry *actiondfs_lookup_cas_blob(
+	struct actiondfs_sb_info *sbi, const char *hash)
+{
+	struct mnt_idmap *idmap = mnt_idmap(sbi->cas_path.mnt);
+	struct qstr shard_name = QSTR_LEN(hash, 2);
+	struct qstr blob_name = QSTR_LEN(hash, ACTIONDFS_HASH_HEX_LEN);
+	struct dentry *shard;
+	struct dentry *blob;
+	int err;
+
+	shard = lookup_one_positive_unlocked(idmap, &shard_name,
+					     sbi->cas_path.dentry);
+	if (IS_ERR(shard))
+		return shard;
+	if (d_managed(shard)) {
+		err = -EXDEV;
+		goto out_shard;
+	}
+	if (d_is_symlink(shard)) {
+		err = -ELOOP;
+		goto out_shard;
+	}
+	if (!d_can_lookup(shard)) {
+		err = -ENOTDIR;
+		goto out_shard;
+	}
+
+	blob = lookup_one_positive_unlocked(idmap, &blob_name, shard);
+	dput(shard);
+	if (IS_ERR(blob))
+		return blob;
+	if (d_managed(blob)) {
+		err = -EXDEV;
+		goto out_blob;
+	}
+	if (d_is_symlink(blob)) {
+		err = -ELOOP;
+		goto out_blob;
+	}
+	if (!d_is_reg(blob)) {
+		err = -EIO;
+		goto out_blob;
+	}
+	return blob;
+
+out_blob:
+	dput(blob);
+	return ERR_PTR(err);
+out_shard:
+	dput(shard);
+	return ERR_PTR(err);
+}
+
 static struct file *actiondfs_open_directory_blob(struct actiondfs_sb_info *sbi,
 						 const char *hash)
 {
 	unsigned int stale_attempts = 0;
-	char path[ACTIONDFS_SHARDED_HASH_PATH_LEN + 1];
 	struct file *file;
-	struct inode *real_inode;
 	struct path real_path;
 	int err;
 
-	actiondfs_sharded_hash_path(hash, path);
 	while (true) {
 		actiondfs_stat_inc(ACTIONDFS_STAT_BLOB_OPEN_ATTEMPTS);
-		err = vfs_path_lookup(sbi->cas_path.dentry, sbi->cas_path.mnt,
-				      path, LOOKUP_FOLLOW | LOOKUP_NO_SYMLINKS |
-					    LOOKUP_NO_XDEV, &real_path);
-		if (err) {
-			file = ERR_PTR(err);
+		real_path.mnt = sbi->cas_path.mnt;
+		real_path.dentry = actiondfs_lookup_cas_blob(sbi, hash);
+		if (IS_ERR(real_path.dentry)) {
+			file = ERR_CAST(real_path.dentry);
 		} else {
-			real_inode = d_inode(real_path.dentry);
-			if (!real_inode || !S_ISREG(real_inode->i_mode)) {
-				path_put(&real_path);
-				return ERR_PTR(-EIO);
-			}
 			file = dentry_open(&real_path, O_RDONLY | O_NONBLOCK,
 					   current_cred());
-			path_put(&real_path);
+			dput(real_path.dentry);
 		}
 		if (!IS_ERR(file))
 			return file;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2283,7 +2283,7 @@ static void actiondfs_insert_staged_inode(struct inode *inode,
 	node->ino = real_inode->i_ino & ~(1ULL << 63);
 	node->mode = (node->mode & S_IFMT) |
 		     (real_inode->i_mode & S_IALLUGO);
-	node->stage_dentry = dget(real_dentry);
+	node->stage_dentry = real_dentry;
 	inode->i_ino = node->ino;
 	inode->i_mode = node->mode;
 	insert_inode_hash(inode);
@@ -2563,7 +2563,6 @@ static int actiondfs_create_staged_child(struct inode *dir,
 		goto out_drop_write;
 	}
 	actiondfs_insert_staged_inode(inode, real_dentry);
-	dput(real_dentry);
 	if (S_ISDIR(mode))
 		inc_nlink(dir);
 	d_instantiate(dentry, inode);

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2200,6 +2200,7 @@ static void actiondfs_init_inode(struct inode *inode,
 {
 	inode->i_ino = node->ino;
 	inode_init_owner(&nop_mnt_idmap, inode, NULL, node->mode);
+	inode_has_no_xattr(inode);
 	inode->i_private = node;
 	simple_inode_init_ts(inode);
 
@@ -3368,6 +3369,8 @@ static int actiondfs_fill_super(struct super_block *sb, struct fs_context *fc)
 				&sbi->stage_path);
 		if (err)
 			goto fail;
+		if (sbi->stage_path.mnt->mnt_sb->s_flags & SB_NOSEC)
+			sb->s_flags |= SB_NOSEC;
 		root->stage_dentry = dget(sbi->stage_path.dentry);
 	} else {
 		sb->s_flags |= SB_RDONLY;

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2326,7 +2326,8 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 {
 	struct actiondfs_sb_info *sbi = actiondfs_sbi(dir->i_sb);
 	struct actiondfs_cached_child *input_child = NULL;
-	struct path parent_path;
+	struct qstr name = QSTR_LEN(dentry->d_name.name,
+				    dentry->d_name.len);
 	struct dentry *real_dentry;
 	struct inode *real_inode;
 	struct inode *inode = NULL;
@@ -2336,17 +2337,20 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	u64 size = 0;
 	int err;
 
-	parent_path.mnt = sbi->stage_path.mnt;
-	parent_path.dentry = stage_dentry;
-	err = actiondfs_stage_lookup_child(&parent_path, dentry->d_name.name,
-					   dentry->d_name.len, &real_dentry);
-	if (err) {
+	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CHILD_LOOKUPS);
+	real_dentry = lookup_one_unlocked(mnt_idmap(sbi->stage_path.mnt),
+					 &name, stage_dentry);
+	if (IS_ERR(real_dentry)) {
+		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CHILD_LOOKUP_ERRORS);
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_ERRORS);
-		return ERR_PTR(err);
+		return ERR_CAST(real_dentry);
 	}
 	real_inode = d_inode(real_dentry);
-	if (!real_inode)
+	if (!real_inode) {
+		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CHILD_LOOKUP_NEGATIVE);
 		goto out_negative;
+	}
+	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_CHILD_LOOKUP_HITS);
 
 	mode = real_inode->i_mode;
 	if (S_ISDIR(mode)) {
@@ -2405,21 +2409,21 @@ static struct inode *actiondfs_lookup_staged_inode(struct inode *dir,
 	}
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_HITS);
 
-out_unlock:
-	actiondfs_stage_unlock_child(&parent_path, real_dentry);
+out_put_dentry:
+	dput(real_dentry);
 	if (inode && !IS_ERR(inode) && input_child)
 		actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_INPUT_DIR_MERGES);
 	return inode;
 
 out_negative:
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_NEGATIVE);
-	goto out_unlock;
+	goto out_put_dentry;
 
 out_error:
 	kfree(link_target);
 	actiondfs_stat_inc(ACTIONDFS_STAT_STAGE_INODE_LOOKUP_ERRORS);
 	inode = ERR_PTR(err);
-	goto out_unlock;
+	goto out_put_dentry;
 }
 
 static struct dentry *actiondfs_lookup(struct inode *dir,

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -936,9 +936,14 @@ static int actiondfs_append_cached_child(struct actiondfs_cached_children *child
 	}
 
 	if (children->count == children->capacity) {
+		size_t bytes;
+
 		if (children->capacity > U32_MAX / 2)
 			return -EOVERFLOW;
 		capacity = children->capacity ? children->capacity * 2 : 4;
+		bytes = kmalloc_size_roundup(array_size(capacity,
+						      sizeof(*entries)));
+		capacity = min_t(size_t, bytes / sizeof(*entries), U32_MAX);
 		entries = krealloc_array(children->entries, capacity,
 					 sizeof(*entries), GFP_KERNEL);
 		if (!entries)

--- a/kernel/actiondfs/actiondfs.c
+++ b/kernel/actiondfs/actiondfs.c
@@ -2210,12 +2210,15 @@ static void actiondfs_init_inode(struct inode *inode,
 	} else if (S_ISDIR(node->mode)) {
 		inode->i_op = &actiondfs_dir_iops;
 		inode->i_fop = &actiondfs_dir_fops;
+		inode->i_opflags |= IOP_LOOKUP;
 		set_nlink(inode, 2);
 	} else {
 		inode->i_op = &actiondfs_file_iops;
 		inode->i_fop = &actiondfs_file_fops;
+		inode->i_opflags |= IOP_NOFOLLOW;
 		i_size_write(inode, node->size);
 	}
+	inode->i_opflags |= IOP_FASTPERM;
 }
 
 static struct inode *actiondfs_iget(struct super_block *sb,

--- a/src/action_runner.zig
+++ b/src/action_runner.zig
@@ -646,9 +646,10 @@ fn forkAction(action: ForkAction) !std.os.linux.pid_t {
     };
     for (action.bind_mounts) |mount| childBindMount(mount);
     childSyscallName(linux.chroot(action.chroot_dir.ptr), "chroot");
+    childSyscallName(linux.chdir("/"), "chdir_root");
     childSyscallName(linux.mount("proc", "/proc", "proc", linux.MS.NOSUID | linux.MS.NODEV | linux.MS.NOEXEC, 0), "mount_proc");
-    childSyscallName(linux.chdir(action.cwd.ptr), "chdir");
     childDropPrivileges(action.sandbox_uid, action.sandbox_gid);
+    childSyscallName(linux.chdir(action.cwd.ptr), "chdir");
     childInstallSocketFilter();
     childRestoreSigpipeDefault();
     childWriteSetupComplete();

--- a/test/STRESS_TIMINGS.md
+++ b/test/STRESS_TIMINGS.md
@@ -1,169 +1,172 @@
 # Executor Timing Summary
 
-- Generated: `2026-08-01 15:38:43 EDT`
+- Generated: `2026-08-01 18:19:48 EDT`
 - Mode: `vm`
-- Execute records parsed: `36`
-- Unique action digests: `36`
-- Source log: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-vm-e2e.0mQ13T/darwin-actiond-vm.log`
-- Command: `ACTIOND_E2E_KEEP_TMP=1 ACTIOND_E2E_ACTIONDFS_STATS_PATH=/private/tmp/actiondfs-round-six-final.stats ACTIOND_REPO_BAZEL_FLAGS="--config=remote --config=executor_timing_logs --jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" tools/e2e.sh vm`
+- Execute records parsed: `37`
+- Unique action digests: `37`
+- Source log: `/var/folders/p4/xn8y5q_j24l5xwgwd_jx5c340000gn/T/actiond-vm-e2e.z0b6EM/darwin-actiond-vm.log`
+- Command: `ACTIOND_E2E_KEEP_TMP=1 ACTIOND_E2E_ACTIONDFS_STATS_PATH=/private/tmp/actiondfs-round-seven-final.stats ACTIOND_REPO_BAZEL_FLAGS="--config=remote --config=executor_timing_logs --jobs=32 --distdir=/private/tmp/actiond-audit-distdir --override_repository=llvm++osx+macos_sdk=/private/tmp/actiond-audit-macos-sdk" tools/e2e.sh vm`
 
 ## Stage Timing
 
 All timing values are milliseconds unless noted.
 
-| Stage                 |   Min |   p25 |    p50 |    p75 |    p95 |   Mean |    Max | Share of summed total |
-| --------------------- | ----: | ----: | -----: | -----: | -----: | -----: | -----: | --------------------: |
-| total                 | 2.800 | 7.638 | 15.403 | 21.545 | 44.323 | 17.931 | 96.064 |                100.0% |
-| input fetch/setup     | 0.265 | 0.304 |  0.320 |  0.369 |  0.718 |  0.385 |  0.774 |                  2.1% |
-| execute               | 2.239 | 6.911 | 14.545 | 19.252 | 36.624 | 16.418 | 94.466 |                 91.6% |
-| output upload/collect | 0.073 | 0.185 |  0.417 |  0.947 |  5.558 |  1.128 | 10.451 |                  6.3% |
+| Stage                 |   Min |    p25 |    p50 |     p75 |     p95 |   Mean |     Max | Share of summed total |
+| --------------------- | ----: | -----: | -----: | ------: | ------: | -----: | ------: | --------------------: |
+| total                 | 1.448 | 19.294 | 46.697 | 110.509 | 179.615 | 66.307 | 211.392 |                100.0% |
+| input fetch/setup     | 0.237 |  0.302 |  0.321 |   0.535 |   2.819 |  0.753 |   7.749 |                  1.1% |
+| execute               | 1.106 | 18.792 | 45.921 | 109.871 | 157.196 | 62.818 | 210.164 |                 94.7% |
+| output upload/collect | 0.069 |  0.166 |  0.341 |   0.609 |   6.771 |  2.735 |  62.242 |                  4.1% |
 
 ## Mount And Output Counts
 
 | Metric             | Min | p25 | p50 | p75 | p95 | Mean | Max |
 | ------------------ | --: | --: | --: | --: | --: | ---: | --: |
-| bind mounts        |   4 |   4 |   4 |   4 |   4 |  4.0 |   4 |
-| output files       |   1 |   1 |   1 |   1 |   1 |  3.7 |  97 |
+| bind mounts        |   2 |   4 |   4 |   4 |   4 |  3.9 |   4 |
+| output files       |   1 |   1 |   1 |   1 |   1 |  3.6 |  97 |
 | output directories |   0 |   1 |   1 |   1 |   1 |  0.9 |   1 |
 
 ## Stage Timing By Stress Case
 
 | Stress Case                | Actions | Total p25 | Total p50 | Total p75 | Total p95 | Input p50 | Execute p50 | Output p50 | Mounts p50 |
 | -------------------------- | ------: | --------: | --------: | --------: | --------: | --------: | ----------: | ---------: | ---------: |
-| aggregate                  |       1 |    21.765 |    21.765 |    21.765 |    21.765 |     0.334 |      21.358 |      0.073 |          4 |
-| bare_individual_files      |       4 |    14.152 |    15.531 |    19.003 |    25.750 |     0.310 |      14.864 |      0.350 |          4 |
-| filesystem_regression      |       1 |    96.064 |    96.064 |    96.064 |    96.064 |     0.403 |      94.466 |      1.194 |          4 |
-| generated_file_producer    |       1 |    40.791 |    40.791 |    40.791 |    40.791 |     0.729 |      34.097 |      5.964 |          4 |
-| generated_individual_files |       4 |     4.759 |     5.354 |     8.250 |    14.238 |     0.508 |       4.325 |      0.336 |          4 |
-| generated_tree_producer    |       1 |    54.918 |    54.918 |    54.918 |    54.918 |     0.265 |      44.202 |     10.451 |          4 |
-| generated_tree_reuse       |       8 |     6.399 |     9.482 |    15.911 |    21.792 |     0.323 |       8.946 |      0.179 |          4 |
-| mixed_all                  |       1 |    21.317 |    21.317 |    21.317 |    21.317 |     0.309 |      18.169 |      2.839 |          4 |
-| nested_individual_files    |       8 |     7.202 |    14.776 |    19.407 |    23.647 |     0.315 |      13.525 |      0.691 |          4 |
-| pids_one_regression        |       1 |     8.981 |     8.981 |     8.981 |     8.981 |     0.328 |       8.493 |      0.160 |          4 |
-| source_dir_tree            |       4 |    15.268 |    17.018 |    19.448 |    24.224 |     0.325 |      16.561 |      0.339 |          4 |
-| symlink_input_consumer     |       1 |     2.800 |     2.800 |     2.800 |     2.800 |     0.287 |       2.239 |      0.274 |          4 |
-| timeout_recovery           |       1 |    22.876 |    22.876 |    22.876 |    22.876 |     0.683 |      21.918 |      0.275 |          4 |
+| aggregate                  |       1 |    20.198 |    20.198 |    20.198 |    20.198 |     0.297 |      19.833 |      0.069 |          4 |
+| bare_individual_files      |       4 |    33.319 |    54.248 |    86.023 |   122.113 |     0.311 |      41.220 |      0.627 |          4 |
+| filesystem_regression      |       1 |   186.060 |   186.060 |   186.060 |   186.060 |     2.613 |     182.837 |      0.609 |          4 |
+| generated_file_producer    |       1 |    72.237 |    72.237 |    72.237 |    72.237 |     1.088 |      66.935 |      4.214 |          4 |
+| generated_individual_files |       4 |    15.871 |    17.821 |    34.459 |    69.757 |     0.310 |      17.252 |      0.324 |          4 |
+| generated_tree_producer    |       1 |   178.003 |   178.003 |   178.003 |   178.003 |     0.302 |     115.459 |     62.242 |          4 |
+| generated_tree_reuse       |       8 |    36.673 |    62.610 |   110.657 |   113.499 |     0.495 |      62.052 |      0.177 |          4 |
+| mixed_all                  |       1 |   114.812 |   114.812 |   114.812 |   114.812 |     0.353 |     111.190 |      3.268 |          4 |
+| nested_individual_files    |       8 |    46.193 |    69.945 |    91.947 |   185.322 |     0.319 |      67.985 |      0.491 |          4 |
+| pids_one_regression        |       1 |    18.152 |    18.152 |    18.152 |    18.152 |     0.312 |      17.704 |      0.135 |          4 |
+| source_dir_tree            |       4 |    14.190 |    17.024 |    52.322 |   131.588 |     0.286 |      16.558 |      0.253 |          4 |
+| symlink_input_consumer     |       1 |     7.427 |     7.427 |     7.427 |     7.427 |     0.308 |       6.867 |      0.251 |          4 |
+| timeout_recovery           |       1 |    14.744 |    14.744 |    14.744 |    14.744 |     0.569 |      14.049 |      0.126 |          4 |
+| unknown                    |       1 |     1.448 |     1.448 |     1.448 |     1.448 |     0.237 |       1.106 |      0.105 |          2 |
 
 ## Visible Overhead Estimate
 
 `process/io` is excluded here because it is mostly the action process runtime plus stdout/stderr drain.
 
-| Metric                    |   Min |   p25 |   p50 |    p75 |    p95 |   Mean |    Max | Share of summed total |
-| ------------------------- | ----: | ----: | ----: | -----: | -----: | -----: | -----: | --------------------: |
-| fixed overhead, no wait   | 1.922 | 4.703 | 9.708 | 15.758 | 27.705 | 11.656 | 37.169 |                 65.0% |
-| fixed overhead, with wait | 1.922 | 4.703 | 9.708 | 16.919 | 27.705 | 11.856 | 37.169 |                 66.1% |
+| Metric                    |   Min |    p25 |    p50 |    p75 |    p95 |   Mean |     Max | Share of summed total |
+| ------------------------- | ----: | -----: | -----: | -----: | -----: | -----: | ------: | --------------------: |
+| fixed overhead, no wait   | 1.122 | 13.555 | 31.299 | 38.040 | 84.384 | 35.131 | 186.093 |                 53.0% |
+| fixed overhead, with wait | 1.122 | 13.555 | 31.815 | 38.040 | 96.734 | 35.901 | 186.093 |                 54.1% |
 
 ## Runner Timing
 
 These values split the `execute` bucket. `child setup` includes successful `execve`; `process/io` starts after close-on-exec confirmation and includes action runtime and stdout/stderr drain.
 
-| Runner Stage   |   Min |   p25 |   p50 |   p75 |    p95 |  Mean |    Max | Share of execute |
-| -------------- | ----: | ----: | ----: | ----: | -----: | ----: | -----: | ---------------: |
-| parent prepare | 0.099 | 0.117 | 0.270 | 6.675 | 22.877 | 4.427 | 24.358 |            27.0% |
-| fork           | 0.134 | 0.218 | 0.264 | 0.529 |  1.192 | 0.441 |  1.442 |             2.7% |
-| child setup    | 0.819 | 1.635 | 2.306 | 5.647 | 18.052 | 5.275 | 18.704 |            32.1% |
-| process/io     | 0.600 | 1.487 | 2.439 | 4.551 | 13.859 | 6.046 | 88.532 |            36.8% |
-| wait           | 0.000 | 0.000 | 0.000 | 0.000 |  0.384 | 0.200 |  5.675 |             1.2% |
-| stdio digest   | 0.000 | 0.000 | 0.000 | 0.001 |  0.001 | 0.000 |  0.001 |             0.0% |
+| Runner Stage   |   Min |   p25 |    p50 |    p75 |     p95 |   Mean |     Max | Share of execute |
+| -------------- | ----: | ----: | -----: | -----: | ------: | -----: | ------: | ---------------: |
+| parent prepare | 0.030 | 0.113 |  3.474 | 15.014 |  23.418 |  7.602 |  33.307 |            12.1% |
+| fork           | 0.121 | 0.303 |  0.653 |  2.076 |  10.871 |  2.123 |  12.015 |             3.4% |
+| child setup    | 0.197 | 5.594 | 12.433 | 28.355 |  57.755 | 21.917 | 184.087 |            34.9% |
+| process/io     | 0.318 | 2.938 |  6.884 | 45.981 | 124.798 | 30.363 | 154.147 |            48.3% |
+| wait           | 0.000 | 0.000 |  0.000 |  0.000 |   2.697 |  0.770 |  15.438 |             1.2% |
+| stdio digest   | 0.000 | 0.000 |  0.000 |  0.001 |   0.002 |  0.001 |   0.009 |             0.0% |
 
-| Stress Case                | Digest         | Parent Prep |  Fork | Child Setup | Process/IO |  Wait | Stdio Digest | Setup Signaled |
-| -------------------------- | -------------- | ----------: | ----: | ----------: | ---------: | ----: | -----------: | -------------- |
-| aggregate                  | `1aaef86306e4` |       0.129 | 0.241 |      18.301 |      2.642 | 0.000 |        0.001 | True           |
-| bare_individual_files      | `066472414ea9` |      10.339 | 0.445 |       2.710 |      0.781 | 0.000 |        0.000 | True           |
-| bare_individual_files      | `2bf32e1a816e` |       0.117 | 0.212 |      14.195 |      0.867 | 0.000 |        0.000 | True           |
-| bare_individual_files      | `5f0c7908f803` |      23.502 | 0.182 |       2.102 |      1.158 | 0.000 |        0.001 | True           |
-| bare_individual_files      | `9ddf9d0661e8` |       4.309 | 0.963 |       2.074 |      3.677 | 0.000 |        0.001 | True           |
-| filesystem_regression      | `a889da71fec5` |       3.170 | 0.628 |       2.111 |     88.532 | 0.000 |        0.000 | True           |
-| generated_file_producer    | `ce0a87dadeaf` |      22.669 | 0.256 |       2.482 |      8.666 | 0.000 |        0.001 | True           |
-| generated_individual_files | `07134f6f78fb` |      10.292 | 0.473 |       2.257 |      1.502 | 0.000 |        0.000 | True           |
-| generated_individual_files | `1ada216cf349` |       0.122 | 1.442 |       1.107 |      1.541 | 0.000 |        0.000 | True           |
-| generated_individual_files | `2fcd9276e686` |       0.109 | 1.348 |       0.852 |      2.077 | 0.000 |        0.001 | True           |
-| generated_individual_files | `963770016a83` |       0.137 | 0.442 |       0.819 |      2.043 | 0.000 |        0.000 | True           |
-| generated_tree_producer    | `a0e22e4a2449` |      24.358 | 0.134 |       1.961 |     17.723 | 0.000 |        0.001 | True           |
-| generated_tree_reuse       | `234fe92db0c4` |       8.840 | 0.537 |       2.457 |      2.662 | 0.000 |        0.001 | True           |
-| generated_tree_reuse       | `307f8dd32223` |       4.255 | 0.179 |       1.653 |      4.424 | 0.000 |        0.001 | True           |
-| generated_tree_reuse       | `31ecae29e592` |       0.130 | 0.196 |       4.773 |      2.221 | 0.000 |        0.000 | True           |
-| generated_tree_reuse       | `3a94355a7850` |       0.099 | 0.195 |       1.732 |      1.411 | 0.000 |        0.001 | True           |
-| generated_tree_reuse       | `3f5910cbd10a` |       0.261 | 0.255 |       1.989 |      1.341 | 0.000 |        0.000 | True           |
-| generated_tree_reuse       | `958cf2efa665` |       0.157 | 0.228 |      14.039 |      1.441 | 0.000 |        0.001 | True           |
-| generated_tree_reuse       | `b57daa400252` |      12.385 | 1.140 |       1.366 |      6.658 | 1.536 |        0.000 | True           |
-| generated_tree_reuse       | `f1aa103ccd7c` |       0.117 | 0.527 |       2.218 |      3.448 | 0.000 |        0.000 | True           |
-| mixed_all                  | `400c2bebfdf7` |       0.105 | 0.257 |       5.214 |     12.572 | 0.000 |        0.001 | True           |
-| nested_individual_files    | `00a5c8fd5eca` |       0.134 | 0.265 |      12.860 |      5.493 | 0.000 |        0.000 | True           |
-| nested_individual_files    | `06648fa82c90` |       5.043 | 0.253 |       1.228 |      3.685 | 0.000 |        0.001 | True           |
-| nested_individual_files    | `0e936d2585e1` |       0.114 | 0.220 |      18.704 |      1.623 | 0.000 |        0.000 | True           |
-| nested_individual_files    | `38e0080a81a7` |       0.115 | 0.208 |      15.868 |      1.725 | 0.000 |        0.001 | True           |
-| nested_individual_files    | `6e61d7c5c043` |       0.114 | 0.213 |       1.572 |      2.024 | 0.000 |        0.001 | True           |
-| nested_individual_files    | `7bb6083de2c1` |       0.278 | 0.251 |       3.609 |      2.952 | 0.000 |        0.000 | True           |
-| nested_individual_files    | `7ebc5b535734` |       0.667 | 0.341 |      11.347 |      4.417 | 0.000 |        0.000 | True           |
-| nested_individual_files    | `a455f1d89ad8` |       0.110 | 0.263 |       1.580 |      2.236 | 0.000 |        0.000 | True           |
-| pids_one_regression        | `bbe16c49ab86` |       0.122 | 0.307 |       6.946 |      1.084 | 0.000 |        0.001 | True           |
-| source_dir_tree            | `35ad590c3e20` |       6.631 | 0.303 |       2.926 |      0.600 | 0.000 |        0.000 | True           |
-| source_dir_tree            | `94ef482d0fd5` |       7.094 | 0.854 |       4.140 |      4.930 | 0.000 |        0.000 | True           |
-| source_dir_tree            | `98458d72ec38` |       6.144 | 0.752 |       1.308 |      7.867 | 0.000 |        0.000 | True           |
-| source_dir_tree            | `f176f6534568` |       6.808 | 0.417 |       2.355 |      7.892 | 5.675 |        0.000 | True           |
-| symlink_input_consumer     | `e7ebd25b87b9` |       0.109 | 0.193 |       1.058 |      0.857 | 0.000 |        0.000 | True           |
-| timeout_recovery           | `ed01de57e2a7` |       0.288 | 0.740 |      17.969 |      2.868 | 0.000 |        0.001 | True           |
+| Stress Case                | Digest         | Parent Prep |   Fork | Child Setup | Process/IO |   Wait | Stdio Digest | Setup Signaled |
+| -------------------------- | -------------- | ----------: | -----: | ----------: | ---------: | -----: | -----------: | -------------- |
+| aggregate                  | `097d7589806b` |       0.109 |  0.303 |      16.791 |      2.607 |  0.000 |        0.001 | True           |
+| bare_individual_files      | `90cce354641e` |      16.998 |  2.076 |      52.792 |     58.782 |  0.000 |        0.002 | True           |
+| bare_individual_files      | `cfea754f9880` |      11.678 |  8.589 |       7.016 |     34.918 |  0.000 |        0.000 | True           |
+| bare_individual_files      | `d227993ae34f` |       0.125 |  0.460 |      12.805 |      4.277 |  2.439 |        0.000 | True           |
+| bare_individual_files      | `faa36aaa12ef` |       7.630 |  0.300 |       6.573 |      5.617 |  0.000 |        0.009 | True           |
+| filesystem_regression      | `d6e431f72b37` |      15.310 | 12.015 |       0.197 |    154.147 |  1.115 |        0.000 | True           |
+| generated_file_producer    | `0ab29dfeee67` |       0.105 |  2.194 |      24.369 |     40.254 |  0.000 |        0.000 | True           |
+| generated_individual_files | `8949618893dd` |      13.240 |  2.434 |       5.594 |     54.267 |  2.233 |        0.001 | True           |
+| generated_individual_files | `8e7053a36faf` |       8.184 |  0.449 |       3.598 |      6.884 |  0.000 |        0.001 | True           |
+| generated_individual_files | `ac62596d2eae` |       0.091 |  0.219 |      11.867 |      2.938 |  0.000 |        0.000 | True           |
+| generated_individual_files | `d7beec3fc619` |       0.104 |  0.332 |      11.629 |      3.266 |  0.000 |        0.000 | True           |
+| generated_tree_producer    | `f8cb8cf8722c` |       7.494 |  0.445 |       7.026 |     84.991 | 15.438 |        0.001 | True           |
+| generated_tree_reuse       | `4f9d33590a97` |       0.123 |  0.323 |      17.583 |     45.981 |  0.000 |        0.000 | True           |
+| generated_tree_reuse       | `ad080d1d4b46` |      16.020 |  0.850 |      17.171 |      0.677 |  0.000 |        0.000 | True           |
+| generated_tree_reuse       | `b82ea83117e0` |      24.852 |  2.076 |       7.014 |     73.544 |  2.800 |        0.000 | True           |
+| generated_tree_reuse       | `bdbccf204e0e` |       0.228 |  0.602 |      15.987 |      1.602 |  0.000 |        0.000 | True           |
+| generated_tree_reuse       | `c222b682e1e5` |      15.568 | 11.700 |      28.903 |     51.000 |  2.671 |        0.000 | True           |
+| generated_tree_reuse       | `cc2d17d56174` |      15.014 | 10.664 |       6.815 |     27.547 |  0.000 |        0.001 | True           |
+| generated_tree_reuse       | `ec3c5569c6cf` |      33.307 |  0.409 |      77.610 |      2.884 |  0.000 |        0.000 | True           |
+| generated_tree_reuse       | `f58a3550a687` |       0.093 |  0.665 |      33.534 |      0.873 |  0.000 |        0.002 | True           |
+| mixed_all                  | `ff909e41f5d7` |      22.656 |  0.242 |       8.827 |     77.636 |  1.788 |        0.000 | True           |
+| nested_individual_files    | `515cc9e83e3d` |       1.190 |  1.479 |      32.946 |     33.272 |  0.000 |        0.000 | True           |
+| nested_individual_files    | `6b51fb6999bc` |      23.059 |  7.960 |      37.940 |      6.362 |  0.000 |        0.000 | True           |
+| nested_individual_files    | `816552fd7392` |       0.124 |  0.653 |     184.087 |     25.280 |  0.000 |        0.001 | True           |
+| nested_individual_files    | `97febd68ffa3` |      12.919 |  0.294 |      28.355 |      4.331 |  0.000 |        0.001 | True           |
+| nested_individual_files    | `a85c70689335` |       0.075 |  0.291 |      36.883 |     29.797 |  0.000 |        0.000 | True           |
+| nested_individual_files    | `c595420ad290` |       0.105 |  3.134 |      39.664 |      0.859 |  0.000 |        0.000 | True           |
+| nested_individual_files    | `f697e529f79f` |       0.137 |  0.941 |       4.858 |    130.155 |  0.000 |        0.001 | True           |
+| nested_individual_files    | `f96dbd47704b` |      20.254 |  2.316 |       4.668 |     10.081 |  0.000 |        0.001 | True           |
+| pids_one_regression        | `9270a8412a96` |       0.127 |  0.281 |      16.083 |      1.188 |  0.000 |        0.000 | True           |
+| source_dir_tree            | `64c12911a3b8` |       3.576 |  0.916 |       2.688 |      4.486 |  0.000 |        0.000 | True           |
+| source_dir_tree            | `67e7d6014831` |       3.474 |  0.509 |       4.735 |      5.519 |  0.000 |        0.001 | True           |
+| source_dir_tree            | `eaf41c0a7f6e` |       6.942 |  0.903 |       3.083 |      7.851 |  0.000 |        0.000 | True           |
+| source_dir_tree            | `fc7ef573df10` |       0.113 |  0.296 |      26.877 |    123.459 |  0.000 |        0.001 | True           |
+| symlink_input_consumer     | `f22dfeb3cc2a` |       0.108 |  0.811 |       1.295 |      4.627 |  0.000 |        0.001 | True           |
+| timeout_recovery           | `bc69c98c3696` |       0.129 |  0.298 |      12.433 |      1.158 |  0.000 |        0.000 | True           |
+| unknown                    | `e6380fd0c4ff` |       0.030 |  0.121 |       0.628 |      0.318 |  0.000 |        0.000 | True           |
 
 ## VM Bridge Timing
 
 These are raw TCP-to-vsock pump connection measurements logged by `darwin-actiond serve-vm`.
 
-- Bridge connections logged: `6`
-- Total client to guest bytes: `1.43 MiB`
+- Bridge connections logged: `10`
+- Total client to guest bytes: `1.47 MiB`
 - Total guest to client bytes: `0.30 MiB`
 - Pump errors: read=`0`, write=`0`
 
-| Bridge Metric          |     Min |     p25 |      p50 |      p75 |      p95 |     Mean |      Max |
-| ---------------------- | ------: | ------: | -------: | -------: | -------: | -------: | -------: |
-| connection elapsed     | 155.124 | 309.787 | 1899.559 | 3321.879 | 4764.864 | 2128.014 | 5237.991 |
-| client to guest KiB    |     0.0 |     6.8 |     19.6 |    371.2 |    819.7 |    243.4 |    930.1 |
-| guest to client KiB    |     0.0 |     1.3 |      2.2 |     81.9 |    173.4 |     51.5 |    195.0 |
-| client to guest reads  |       1 |      10 |       14 |      260 |      399 |    133.0 |      418 |
-| client to guest writes |       1 |      10 |       14 |      260 |      399 |    133.0 |      418 |
-| guest to client reads  |       0 |      10 |       16 |      338 |      458 |    158.2 |      463 |
-| guest to client writes |       0 |      10 |       16 |      338 |      458 |    158.2 |      463 |
+| Bridge Metric          |     Min |      p25 |      p50 |      p75 |      p95 |     Mean |      Max |
+| ---------------------- | ------: | -------: | -------: | -------: | -------: | -------: | -------: |
+| connection elapsed     | 186.088 | 1190.171 | 1324.212 | 2915.719 | 5545.221 | 2203.577 | 5575.022 |
+| client to guest KiB    |     0.0 |     19.6 |    141.4 |    184.7 |    431.1 |    150.8 |    581.9 |
+| guest to client KiB    |     0.0 |      1.3 |     21.6 |     46.7 |     86.5 |     31.0 |    103.5 |
+| client to guest reads  |       1 |       12 |       92 |      260 |      314 |    132.1 |      339 |
+| client to guest writes |       1 |       12 |       92 |      260 |      314 |    132.1 |      339 |
+| guest to client reads  |       0 |       10 |       91 |      198 |      246 |    108.7 |      270 |
+| guest to client writes |       0 |       10 |       91 |      198 |      246 |    108.7 |      270 |
 
 ## Per Action
 
-| Stress Case                | Digest         |  Total | Input | Execute | Output | Bind Mounts |        Outputs |
-| -------------------------- | -------------- | -----: | ----: | ------: | -----: | ----------: | -------------: |
-| aggregate                  | `1aaef86306e4` | 21.765 | 0.334 |  21.358 |  0.073 |           4 |  1 file, 0 dir |
-| bare_individual_files      | `066472414ea9` | 14.869 | 0.315 |  14.297 |  0.257 |           4 |  1 file, 1 dir |
-| bare_individual_files      | `2bf32e1a816e` | 16.192 | 0.318 |  15.431 |  0.443 |           4 |  1 file, 1 dir |
-| bare_individual_files      | `5f0c7908f803` | 27.436 | 0.297 |  26.984 |  0.155 |           4 |  1 file, 1 dir |
-| bare_individual_files      | `9ddf9d0661e8` | 12.000 | 0.304 |  11.042 |  0.654 |           4 |  1 file, 1 dir |
-| filesystem_regression      | `a889da71fec5` | 96.064 | 0.403 |  94.466 |  1.194 |           4 |  1 file, 1 dir |
-| generated_file_producer    | `ce0a87dadeaf` | 40.791 | 0.729 |  34.097 |  5.964 |           4 | 97 file, 0 dir |
-| generated_individual_files | `07134f6f78fb` | 15.735 | 0.774 |  14.543 |  0.418 |           4 |  1 file, 1 dir |
-| generated_individual_files | `1ada216cf349` |  5.755 | 0.441 |   4.240 |  1.074 |           4 |  1 file, 1 dir |
-| generated_individual_files | `2fcd9276e686` |  4.954 | 0.290 |   4.410 |  0.254 |           4 |  1 file, 1 dir |
-| generated_individual_files | `963770016a83` |  4.176 | 0.574 |   3.459 |  0.142 |           4 |  1 file, 1 dir |
-| generated_tree_producer    | `a0e22e4a2449` | 54.918 | 0.265 |  44.202 | 10.451 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `234fe92db0c4` | 15.071 | 0.334 |  14.546 |  0.190 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `307f8dd32223` | 11.144 | 0.294 |  10.549 |  0.302 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `31ecae29e592` |  7.819 | 0.359 |   7.343 |  0.117 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `3a94355a7850` |  3.893 | 0.305 |   3.454 |  0.134 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `3f5910cbd10a` |  4.308 | 0.303 |   3.867 |  0.138 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `958cf2efa665` | 18.433 | 0.366 |  15.942 |  2.125 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `b57daa400252` | 23.601 | 0.311 |  23.120 |  0.169 |           4 |  1 file, 1 dir |
-| generated_tree_reuse       | `f1aa103ccd7c` |  7.096 | 0.358 |   6.325 |  0.413 |           4 |  1 file, 1 dir |
-| mixed_all                  | `400c2bebfdf7` | 21.317 | 0.309 |  18.169 |  2.839 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `00a5c8fd5eca` | 24.818 | 0.621 |  18.774 |  5.422 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `06648fa82c90` | 11.444 | 0.308 |  10.241 |  0.895 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `0e936d2585e1` | 21.472 | 0.301 |  20.683 |  0.487 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `38e0080a81a7` | 18.718 | 0.305 |  17.978 |  0.435 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `6e61d7c5c043` |  5.278 | 0.308 |   3.945 |  1.024 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `7bb6083de2c1` |  7.843 | 0.321 |   7.106 |  0.416 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `7ebc5b535734` | 18.108 | 0.378 |  16.809 |  0.921 |           4 |  1 file, 1 dir |
-| nested_individual_files    | `a455f1d89ad8` |  5.058 | 0.367 |   4.213 |  0.478 |           4 |  1 file, 1 dir |
-| pids_one_regression        | `bbe16c49ab86` |  8.981 | 0.328 |   8.493 |  0.160 |           4 |  1 file, 1 dir |
-| source_dir_tree            | `35ad590c3e20` | 11.335 | 0.359 |  10.503 |  0.472 |           4 |  1 file, 1 dir |
-| source_dir_tree            | `94ef482d0fd5` | 17.458 | 0.291 |  17.037 |  0.129 |           4 |  1 file, 1 dir |
-| source_dir_tree            | `98458d72ec38` | 16.579 | 0.287 |  16.085 |  0.207 |           4 |  1 file, 1 dir |
-| source_dir_tree            | `f176f6534568` | 25.419 | 0.715 |  23.182 |  1.522 |           4 |  1 file, 1 dir |
-| symlink_input_consumer     | `e7ebd25b87b9` |  2.800 | 0.287 |   2.239 |  0.274 |           4 |  1 file, 1 dir |
-| timeout_recovery           | `ed01de57e2a7` | 22.876 | 0.683 |  21.918 |  0.275 |           4 |  1 file, 1 dir |
+| Stress Case                | Digest         |   Total | Input | Execute | Output | Bind Mounts |        Outputs |
+| -------------------------- | -------------- | ------: | ----: | ------: | -----: | ----------: | -------------: |
+| aggregate                  | `097d7589806b` |  20.198 | 0.297 |  19.833 |  0.069 |           4 |  1 file, 0 dir |
+| bare_individual_files      | `90cce354641e` | 131.135 | 0.288 | 130.680 |  0.166 |           4 |  1 file, 1 dir |
+| bare_individual_files      | `cfea754f9880` |  70.986 | 7.749 |  62.231 |  1.005 |           4 |  1 file, 1 dir |
+| bare_individual_files      | `d227993ae34f` |  20.741 | 0.319 |  20.171 |  0.250 |           4 |  1 file, 1 dir |
+| bare_individual_files      | `faa36aaa12ef` |  37.511 | 0.303 |  20.208 | 17.000 |           4 |  1 file, 1 dir |
+| filesystem_regression      | `d6e431f72b37` | 186.060 | 2.613 | 182.837 |  0.609 |           4 |  1 file, 1 dir |
+| generated_file_producer    | `0ab29dfeee67` |  72.237 | 1.088 |  66.935 |  4.214 |           4 | 97 file, 0 dir |
+| generated_individual_files | `8949618893dd` |  78.581 | 0.375 |  77.865 |  0.341 |           4 |  1 file, 1 dir |
+| generated_individual_files | `8e7053a36faf` |  19.752 | 0.300 |  19.146 |  0.306 |           4 |  1 file, 1 dir |
+| generated_individual_files | `ac62596d2eae` |  15.891 | 0.291 |  15.140 |  0.460 |           4 |  1 file, 1 dir |
+| generated_individual_files | `d7beec3fc619` |  15.812 | 0.321 |  15.358 |  0.133 |           4 |  1 file, 1 dir |
+| generated_tree_producer    | `f8cb8cf8722c` | 178.003 | 0.302 | 115.459 | 62.242 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `4f9d33590a97` |  64.459 | 0.303 |  64.028 |  0.128 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `ad080d1d4b46` |  36.264 | 0.651 |  34.749 |  0.864 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `b82ea83117e0` | 111.101 | 0.637 | 110.325 |  0.139 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `bdbccf204e0e` |  19.132 | 0.455 |  18.506 |  0.171 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `c222b682e1e5` | 110.509 | 0.535 | 109.871 |  0.103 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `cc2d17d56174` |  60.761 | 0.387 |  60.077 |  0.297 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `ec3c5569c6cf` | 114.790 | 0.375 | 114.232 |  0.183 |           4 |  1 file, 1 dir |
+| generated_tree_reuse       | `f58a3550a687` |  36.810 | 0.723 |  35.231 |  0.856 |           4 |  1 file, 1 dir |
+| mixed_all                  | `ff909e41f5d7` | 114.812 | 0.353 | 111.190 |  3.268 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `515cc9e83e3d` |  72.038 | 0.302 |  68.909 |  2.826 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `6b51fb6999bc` |  76.960 | 1.043 |  75.415 |  0.502 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `816552fd7392` | 211.392 | 0.308 | 210.164 |  0.919 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `97febd68ffa3` |  46.697 | 0.297 |  45.921 |  0.479 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `a85c70689335` |  67.853 | 0.330 |  67.062 |  0.460 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `c595420ad290` |  44.681 | 0.355 |  43.797 |  0.528 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `f697e529f79f` | 136.907 | 0.308 | 136.126 |  0.472 |           4 |  1 file, 1 dir |
+| nested_individual_files    | `f96dbd47704b` |  41.547 | 3.642 |  37.486 |  0.419 |           4 |  1 file, 1 dir |
+| pids_one_regression        | `9270a8412a96` |  18.152 | 0.312 |  17.704 |  0.135 |           4 |  1 file, 1 dir |
+| source_dir_tree            | `64c12911a3b8` |  12.502 | 0.288 |  11.698 |  0.516 |           4 |  1 file, 1 dir |
+| source_dir_tree            | `67e7d6014831` |  14.753 | 0.283 |  14.325 |  0.145 |           4 |  1 file, 1 dir |
+| source_dir_tree            | `eaf41c0a7f6e` |  19.294 | 0.330 |  18.792 |  0.172 |           4 |  1 file, 1 dir |
+| source_dir_tree            | `fc7ef573df10` | 151.404 | 0.284 | 150.786 |  0.334 |           4 |  1 file, 1 dir |
+| symlink_input_consumer     | `f22dfeb3cc2a` |   7.427 | 0.308 |   6.867 |  0.251 |           4 |  1 file, 1 dir |
+| timeout_recovery           | `bc69c98c3696` |  14.744 | 0.569 |  14.049 |  0.126 |           4 |  1 file, 1 dir |
+| unknown                    | `e6380fd0c4ff` |   1.448 | 0.237 |   1.106 |  0.105 |           2 |  1 file, 0 dir |
 
 ## Notes
 

--- a/tools/e2e.sh
+++ b/tools/e2e.sh
@@ -275,6 +275,8 @@ run_vm_e2e() {
   trap 'cleanup_e2e_server $?' EXIT
 
   wait_for_port "${e2e_host}" "${e2e_port}" 180
+  python3 "${repo_root}/tools/e2e_sandbox_regression.py" \
+    "${endpoint}" "${test_workspace}/tool/action-tool"
   run_stress_workspace
   cleanup_e2e_server 0
   trap - EXIT

--- a/tools/e2e_action_tool.zig
+++ b/tools/e2e_action_tool.zig
@@ -758,10 +758,18 @@ fn exerciseFilesystem(
         return filesystemFailure("filesystem output path did not include an output parent");
     var iterable_root = try root.openDir(io, ".", .{ .iterate = true });
     defer iterable_root.close(io);
+    try requireSandboxOwnership(
+        iterable_root.handle,
+        "staged workspace root did not preserve backing filesystem ownership",
+    );
     try expectDirectoryEntry(io, iterable_root, output_path[0..output_root_end], .directory, true);
 
     var output_dir = try root.openDir(io, output_path, .{ .iterate = true });
     defer output_dir.close(io);
+    try requireSandboxOwnership(
+        output_dir.handle,
+        "staged output directory did not preserve backing filesystem ownership",
+    );
     try output_dir.createDirPath(io, "filesystem");
     try requireFilesystem((try output_dir.stat(io)).nlink == 3, "creating a staged subdirectory did not increment the output directory link count");
     try exerciseInputDirectoryLinkCounts(io, root);
@@ -776,6 +784,31 @@ fn exerciseFilesystem(
     try exerciseImmutableInputAuthorization(io, allocator, root, inputs);
     try syncDirectory(dir);
     try syncDirectory(output_dir);
+}
+
+fn requireSandboxOwnership(fd: std.posix.fd_t, comptime message: []const u8) !void {
+    if (comptime @import("builtin").os.tag != .linux) return;
+
+    const linux = std.os.linux;
+    var ownership = std.mem.zeroes(linux.Statx);
+    switch (linux.errno(linux.statx(
+        fd,
+        "",
+        linux.AT.EMPTY_PATH,
+        .{ .UID = true, .GID = true },
+        &ownership,
+    ))) {
+        .SUCCESS => {},
+        else => return filesystemFailure("staged ownership statx failed"),
+    }
+    try requireFilesystem(
+        ownership.mask.UID and ownership.mask.GID,
+        "staged ownership statx omitted uid or gid",
+    );
+    try requireFilesystem(
+        ownership.uid == linux.geteuid() and ownership.gid == linux.getegid(),
+        message,
+    );
 }
 
 fn exerciseDirectoryPermissions(io: std.Io, dir: std.Io.Dir) !void {
@@ -850,6 +883,10 @@ fn exerciseFileMetadata(io: std.Io, dir: std.Io.Dir) !void {
         .permissions = .default_file,
     });
     defer file.close(io);
+    try requireSandboxOwnership(
+        file.handle,
+        "created staged file did not preserve backing filesystem ownership",
+    );
     const payload = "actiondfs staged payload\n";
     try file.writeStreamingAll(io, payload);
     try file.sync(io);

--- a/tools/e2e_sandbox_regression.py
+++ b/tools/e2e_sandbox_regression.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Verify actiond rejects working directories that escape the action chroot."""
+
+import hashlib
+import pathlib
+import struct
+import subprocess
+import sys
+
+
+CAS_METHOD = "/build.bazel.remote.execution.v2.ContentAddressableStorage/BatchUpdateBlobs"
+EXECUTE_METHOD = "/build.bazel.remote.execution.v2.Execution/Execute"
+EXECUTE_RESPONSE_TYPE = b"type.googleapis.com/build.bazel.remote.execution.v2.ExecuteResponse"
+
+
+def varint(value):
+    encoded = bytearray()
+    while value >= 0x80:
+        encoded.append((value & 0x7F) | 0x80)
+        value >>= 7
+    encoded.append(value)
+    return bytes(encoded)
+
+
+def number_field(number, value):
+    return varint(number << 3) + varint(value)
+
+
+def bytes_field(number, value):
+    if isinstance(value, str):
+        value = value.encode()
+    return varint((number << 3) | 2) + varint(len(value)) + value
+
+
+def read_varint(data, offset):
+    value = 0
+    for shift in range(0, 70, 7):
+        if offset >= len(data):
+            raise ValueError("truncated protobuf varint")
+        byte = data[offset]
+        offset += 1
+        value |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return value, offset
+    raise ValueError("invalid protobuf varint")
+
+
+def fields(message):
+    decoded = {}
+    offset = 0
+    while offset < len(message):
+        tag, offset = read_varint(message, offset)
+        number, wire = tag >> 3, tag & 7
+        if number == 0:
+            raise ValueError("invalid protobuf field number")
+        if wire == 0:
+            value, offset = read_varint(message, offset)
+        elif wire == 2:
+            size, offset = read_varint(message, offset)
+            if size > len(message) - offset:
+                raise ValueError("truncated protobuf field")
+            value = message[offset : offset + size]
+            offset += size
+        elif wire in (1, 5):
+            size = 8 if wire == 1 else 4
+            if size > len(message) - offset:
+                raise ValueError("truncated fixed-width protobuf field")
+            value = message[offset : offset + size]
+            offset += size
+        else:
+            raise ValueError("unsupported protobuf wire type")
+        decoded.setdefault(number, []).append(value)
+    return decoded
+
+
+def digest(data):
+    return bytes_field(1, hashlib.sha256(data).hexdigest()) + number_field(2, len(data))
+
+
+def grpc(endpoint, method, payload):
+    request = b"\0" + struct.pack(">I", len(payload)) + payload
+    command = [
+        "curl",
+        "--http2-prior-knowledge",
+        "--silent",
+        "--show-error",
+        "--fail",
+        "--max-time",
+        "60",
+        "--header",
+        "content-type: application/grpc",
+        "--header",
+        "te: trailers",
+        "--data-binary",
+        "@-",
+        "http://" + endpoint + method,
+    ]
+    try:
+        response = subprocess.run(
+            command,
+            input=request,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+            timeout=70,
+        ).stdout
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.decode(errors="replace").strip()
+        raise RuntimeError("gRPC " + method + " failed: " + detail) from error
+
+    messages = []
+    offset = 0
+    while offset < len(response):
+        if len(response) - offset < 5:
+            raise ValueError("truncated gRPC response header")
+        compressed = response[offset]
+        size = struct.unpack_from(">I", response, offset + 1)[0]
+        offset += 5
+        if compressed or size > len(response) - offset:
+            raise ValueError("invalid gRPC response record")
+        messages.append(response[offset : offset + size])
+        offset += size
+    if not messages:
+        raise ValueError("missing gRPC response")
+    return messages
+
+
+def upload(endpoint, blobs):
+    request = b"".join(
+        bytes_field(2, bytes_field(1, blob_digest) + bytes_field(2, data))
+        for blob_digest, data in blobs
+    )
+    response = fields(grpc(endpoint, CAS_METHOD, request)[-1])
+    items = response.get(1, [])
+    if len(items) != len(blobs):
+        raise RuntimeError("BatchUpdateBlobs returned an unexpected blob count")
+    for item in items:
+        status = fields(fields(item).get(2, [b""])[-1])
+        if status.get(1, [0])[-1] != 0:
+            raise RuntimeError("BatchUpdateBlobs rejected a regression blob")
+
+
+def execute(endpoint, action_digest):
+    request = number_field(3, 1) + bytes_field(6, action_digest)
+    operation = fields(grpc(endpoint, EXECUTE_METHOD, request)[-1])
+    if operation.get(3, [0])[-1] != 1:
+        raise RuntimeError("Execute returned an incomplete operation")
+    if 4 in operation:
+        raise RuntimeError("Execute returned an unexpected operation error")
+    if 5 not in operation:
+        raise RuntimeError("Execute returned no response")
+
+    packed = fields(operation[5][-1])
+    if packed.get(1, [b""])[-1] != EXECUTE_RESPONSE_TYPE:
+        raise RuntimeError("Execute returned an unexpected response type")
+    if 2 not in packed:
+        raise RuntimeError("Execute returned no encoded response")
+
+    response = fields(packed[2][-1])
+    status = fields(response.get(3, [b""])[-1])
+    return status.get(1, [0])[-1], response.get(1, [None])[-1]
+
+
+def command(working_directory, arguments, output_paths=()):
+    message = b"".join(bytes_field(1, argument) for argument in arguments)
+    message += bytes_field(6, working_directory)
+    message += b"".join(bytes_field(7, path) for path in output_paths)
+    return message
+
+
+def main():
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: e2e_sandbox_regression.py <host:port> <linux-action-tool>")
+    endpoint = sys.argv[1]
+    executable = pathlib.Path(sys.argv[2]).read_bytes()
+    executable_digest = digest(executable)
+
+    attacks = (
+        ("proc-init-escape", "/proc/1/root/cas"),
+        ("proc-self-escape", "/proc/self/cwd/cas"),
+    )
+    file_node = bytes_field(1, "tool") + bytes_field(2, executable_digest) + number_field(4, 1)
+    directory = bytes_field(1, file_node)
+    for name, target in attacks:
+        directory += bytes_field(3, bytes_field(1, name) + bytes_field(2, target))
+    directory_digest = digest(directory)
+
+    scenarios = [
+        (name, command(name, ("/workspace/tool",)), None)
+        for name, _ in attacks
+    ]
+    scenarios.append(
+        (
+            "staged-output-parent",
+            command("sub", ("/workspace/tool", "--out-file", "out"), ("sub/out",)),
+            "sub/out",
+        )
+    )
+
+    blobs = [(executable_digest, executable), (directory_digest, directory)]
+    actions = []
+    for name, command_bytes, output_path in scenarios:
+        command_digest = digest(command_bytes)
+        action = bytes_field(1, command_digest) + bytes_field(2, directory_digest) + number_field(7, 1)
+        action_digest = digest(action)
+        blobs.extend(((command_digest, command_bytes), (action_digest, action)))
+        actions.append((name, action_digest, output_path))
+    upload(endpoint, blobs)
+
+    for name, action_digest, output_path in actions:
+        status, result = execute(endpoint, action_digest)
+        if output_path is None:
+            if status != 13 or result is not None:
+                raise RuntimeError("working directory escaped its chroot: " + name)
+            continue
+
+        if status != 0 or result is None:
+            raise RuntimeError("benign staged working directory failed")
+        action_result = fields(result)
+        if action_result.get(4, [0])[-1] != 0:
+            raise RuntimeError("benign staged working directory returned a failed action")
+        outputs = [fields(output) for output in action_result.get(2, [])]
+        if not any(
+            output.get(1, [b""])[-1] == output_path.encode()
+            and 2 in output
+            and fields(output[2][-1]).get(2, [0])[-1] > 0
+            for output in outputs
+        ):
+            raise RuntimeError("benign staged working directory did not produce its declared output")
+
+    print("sandbox working-directory escape regressions passed")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, subprocess.SubprocessError, ValueError, RuntimeError) as error:
+        print("sandbox working-directory regression failed: " + str(error), file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
Follow merged #27 with 14 independently reviewable actiondfs optimization and security commits.

Reduce actiondfs work by acquiring 472,190 input backing files through RCU, avoiding approximately 75,358 exclusive staged-directory locks, resolving CAS blobs directly without 13,489 temporary PATH_MAX allocations (about 52.7 MiB), deferring directory iterator allocation and merged-directory metadata, transferring owned backing dentries, reusing complete slab buckets, initializing invariant inode flags, inheriting safe backing-filesystem security flags, and avoiding locks before inode publication.

Contain the working directory immediately after chroot and drop privileges before resolving untrusted Command.working_directory, preventing /proc/self/cwd and /proc/1/root escapes that could access concurrent actions or shared CAS contents. Copy mount-idmapped backing UID/GID to staged synthetic inodes. A direct REAPI VM regression exercises both attack variants and confirms a normal staged working directory remains writable; additional VM assertions validate root, directory, and file ownership.

Validation: all 66 supported ARM64/x86 Bazel build targets and repository tests; standalone timing-parser test; production and instrumented macOS Virtualization.framework VM suites; fresh LLVM VM smoke with 2,017 warmup and 2,106 measured actions; all five GitHub Actions checks passed. Matched CI LLVM comparisons each executed exactly 1,998 actions: Linux actiond 308.045s / native 311.801s = 0.988x versus current main 0.982x; Windows actiond 365.289s / native 380.077s = 0.961x versus current main 1.008x. The Linux delta is 0.66%; Windows improves 4.64%. Both VM timing reports are refreshed.