### PR TITLE
runtime: provide passwd and group entries for sandbox identity

### DIFF
--- a/runtimes/squashfs.bzl
+++ b/runtimes/squashfs.bzl
@@ -9,6 +9,8 @@ pseudo="${output}.pseudo"
 printf '%s\n' \
   "/common/root/etc/hosts F 0 0644 0 0 printf '127.0.0.1 localhost\\n::1 localhost ip6-localhost ip6-loopback\\n'" \
   "/common/root/etc/nsswitch.conf F 0 0644 0 0 printf 'passwd: files\\ngroup: files\\nhosts: files dns\\n'" \
+  "/common/root/etc/passwd F 0 0644 0 0 printf 'root:x:0:0:root:/root:/bin/sh\\nnobody:x:65534:65534:nobody:/:/bin/sh\\n'" \
+  "/common/root/etc/group F 0 0644 0 0 printf 'root:x:0:\\nnogroup:x:65534:\\n'" \
   > "${pseudo}"
 
 append_runtime() {


### PR DESCRIPTION
PostgreSQL initialization currently fails in an actiond sandbox with:

```text
initdb: could not look up effective user ID 65534: No such file or directory
pg_ctl: database system initialization failed
```

The runtime already configures `passwd: files` and `group: files`, but has no
corresponding NSS databases. Generate small `/etc/passwd` and `/etc/group`
pseudo-files containing the existing root and UID/GID 65534 sandbox identities.
No packages are added to the runtime.

A complete runtime image rebuilt successfully (891 actions). Rerunning the
original PostgreSQL/pgvector integration test through the rebuilt VM resolved
UID 65534 to `nobody`, created the cluster directories and configuration, and
advanced to the separate missing System V shared-memory kernel capability.