### PR TITLE
executor: mount read-only sysfs inside isolated actions

### DIFF
--- a/src/action_executor.zig
+++ b/src/action_executor.zig
@@ -2111,6 +2111,7 @@ fn createOutputParent(io: std.Io, work_root: std.Io.Dir, path: []const u8) !void
 fn prepareChrootBaseDirs(io: std.Io, chroot_root: std.Io.Dir) !void {
     try chroot_root.createDirPath(io, "dev");
     try chroot_root.createDirPath(io, "proc");
+    try chroot_root.createDirPath(io, "sys");
     try chroot_root.createDirPath(io, "tmp");
     try chroot_root.createDirPath(io, "var/tmp");
 }
@@ -3641,6 +3642,7 @@ test "prepareChrootBaseDirs creates temporary directories" {
     defer work_dir.close(std.testing.io);
 
     try prepareChrootBaseDirs(std.testing.io, work_dir);
+    try work_dir.access(std.testing.io, "sys", .{});
     try work_dir.access(std.testing.io, "tmp", .{});
     try work_dir.access(std.testing.io, "var/tmp", .{});
 }

--- a/src/action_runner.zig
+++ b/src/action_runner.zig
@@ -648,6 +648,13 @@ fn forkAction(action: ForkAction) !std.os.linux.pid_t {
     childSyscallName(linux.chroot(action.chroot_dir.ptr), "chroot");
     childSyscallName(linux.chdir("/"), "chdir_root");
     childSyscallName(linux.mount("proc", "/proc", "proc", linux.MS.NOSUID | linux.MS.NODEV | linux.MS.NOEXEC, 0), "mount_proc");
+    childSyscallName(linux.mount(
+        "sysfs",
+        "/sys",
+        "sysfs",
+        linux.MS.RDONLY | linux.MS.NOSUID | linux.MS.NODEV | linux.MS.NOEXEC,
+        0,
+    ), "mount_sys");
     childDropPrivileges(action.sandbox_uid, action.sandbox_gid);
     childSyscallName(linux.chdir(action.cwd.ptr), "chdir");
     childInstallSocketFilter();


### PR DESCRIPTION
Hardware-topology discovery inside actiond currently fails with:

```text
hwloc/linux: failed to find sysfs cpu topology directory, aborting linux discovery.
```

Create an action-local `/sys` mount point and mount sysfs read-only after
entering the existing private mount namespace. Keep the mount `nosuid`,
`nodev`, and `noexec`, and extend the existing chroot-directory test.

The ARM64 guest was rebuilt through actiond. A real remote action reads
`/sys/devices/system/cpu/online` and verifies the sysfs mount is read-only;
the original mpi4py integration no longer reports the hwloc topology error
and advances to its separate libfabric initialization issue.